### PR TITLE
Add CONFIG_DIR_NOT_FOUND in StatExceptionCode

### DIFF
--- a/src/main/java/com/amazon/opendistro/opensearch/performanceanalyzer/collectors/StatExceptionCode.java
+++ b/src/main/java/com/amazon/opendistro/opensearch/performanceanalyzer/collectors/StatExceptionCode.java
@@ -72,6 +72,7 @@ public enum StatExceptionCode {
     MISCONFIGURED_OLD_GEN_RCA_HEAP_USED_MISSING("MisconfiguredOldGenRcaHeapUsedMissing"),
     MISCONFIGURED_OLD_GEN_RCA_GC_EVENTS_MISSING("MisconfiguredOldGenRcaGcEventsMissing"),
     TOTAL_MEM_READ_ERROR("TotalMemReadError"),
+    CONFIG_DIR_NOT_FOUND("ConfigDirectoryNotFound"),
     OTHER("Other");
 
     private final String value;


### PR DESCRIPTION
Signoff by: Harold Xiao haoruxia@amazon.com

**Describe the solution you are proposing**
Adding a new stat exception type for config directory not found. The exception is called in [this PR: ](https://github.com/opensearch-project/performance-analyzer/pull/9/files) 

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
