### PR TITLE
Modify JVM gen tuning policy and update the Unit test

### DIFF
--- a/src/main/java/com/amazon/opendistro/opensearch/performanceanalyzer/decisionmaker/deciders/jvm/JvmGenTuningPolicy.java
+++ b/src/main/java/com/amazon/opendistro/opensearch/performanceanalyzer/decisionmaker/deciders/jvm/JvmGenTuningPolicy.java
@@ -164,7 +164,7 @@ public class JvmGenTuningPolicy implements DecisionPolicy {
      * @return a ratio that will decrease the young generation size based on the current ratio
      */
     public int computeDecrease(double currentRatio) {
-        // Don't decrease the (old:young) ratio beyond 5:1
+        // Don't increase the (old:young) ratio beyond 5:1
         if (currentRatio < 0 || currentRatio > 5) {
             return -1;
         }
@@ -177,8 +177,8 @@ public class JvmGenTuningPolicy implements DecisionPolicy {
      * @return a ratio that will increase the young generation size based on the current ratio
      */
     public int computeIncrease(double currentRatio) {
-        // Don't increase the (old:young) ratio beyond 3:1
-        if (currentRatio <= 3) {
+        // Don't decrease the (old:young) ratio below 3:1
+        if (currentRatio < 4) {
             return -1;
         }
         // If the current ratio is egregious (e.g. 50:1) set the ratio to 3:1 immediately

--- a/src/main/java/com/amazon/opendistro/opensearch/performanceanalyzer/decisionmaker/deciders/jvm/JvmGenTuningPolicy.java
+++ b/src/main/java/com/amazon/opendistro/opensearch/performanceanalyzer/decisionmaker/deciders/jvm/JvmGenTuningPolicy.java
@@ -178,7 +178,7 @@ public class JvmGenTuningPolicy implements DecisionPolicy {
      */
     public int computeIncrease(double currentRatio) {
         // Don't increase the (old:young) ratio beyond 3:1
-        if (currentRatio < 3) {
+        if (currentRatio <= 3) {
             return -1;
         }
         // If the current ratio is egregious (e.g. 50:1) set the ratio to 3:1 immediately

--- a/src/test/java/com/amazon/opendistro/opensearch/performanceanalyzer/decisionmaker/deciders/jvm/JvmGenTuningPolicyTest.java
+++ b/src/test/java/com/amazon/opendistro/opensearch/performanceanalyzer/decisionmaker/deciders/jvm/JvmGenTuningPolicyTest.java
@@ -164,8 +164,13 @@ public class JvmGenTuningPolicyTest {
         Assert.assertEquals(1, actions.size());
         Assert.assertTrue(actions.get(0) instanceof JvmGenAction);
         Assert.assertEquals(5, ((JvmGenAction) actions.get(0)).getTargetRatio());
+        mockCurrentRatio(5);
+        actions = policy.evaluate();
+        Assert.assertEquals(1, actions.size());
+        Assert.assertTrue(actions.get(0) instanceof JvmGenAction);
+        Assert.assertEquals(6, ((JvmGenAction) actions.get(0)).getTargetRatio());
         // Should not decrease the young gen size if the ratio is beyond 5:1
-        mockCurrentRatio(6);
+        mockCurrentRatio(5.1);
         actions = policy.evaluate();
         Assert.assertTrue(actions.isEmpty());
         // Make the young generation seem undersized
@@ -184,8 +189,13 @@ public class JvmGenTuningPolicyTest {
         Assert.assertEquals(1, actions.size());
         Assert.assertTrue(actions.get(0) instanceof JvmGenAction);
         Assert.assertEquals(4, ((JvmGenAction) actions.get(0)).getTargetRatio());
-        // Should not increase the young gen size if the ratio is not beyond 3:1
-        mockCurrentRatio(3);
+        mockCurrentRatio(4);
+        actions = policy.evaluate();
+        Assert.assertEquals(1, actions.size());
+        Assert.assertTrue(actions.get(0) instanceof JvmGenAction);
+        Assert.assertEquals(3, ((JvmGenAction) actions.get(0)).getTargetRatio());
+        // Should not increase the young gen size if the ratio is not beyond 4:1
+        mockCurrentRatio(3.9);
         actions = policy.evaluate();
         Assert.assertTrue(actions.isEmpty());
     }

--- a/src/test/java/com/amazon/opendistro/opensearch/performanceanalyzer/decisionmaker/deciders/jvm/JvmGenTuningPolicyTest.java
+++ b/src/test/java/com/amazon/opendistro/opensearch/performanceanalyzer/decisionmaker/deciders/jvm/JvmGenTuningPolicyTest.java
@@ -164,6 +164,10 @@ public class JvmGenTuningPolicyTest {
         Assert.assertEquals(1, actions.size());
         Assert.assertTrue(actions.get(0) instanceof JvmGenAction);
         Assert.assertEquals(5, ((JvmGenAction) actions.get(0)).getTargetRatio());
+        // Should not decrease the young gen size if the ratio is beyond 5:1
+        mockCurrentRatio(6);
+        actions = policy.evaluate();
+        Assert.assertTrue(actions.isEmpty());
         // Make the young generation seem undersized
         mockRcaIssues(10, ResourceUtil.YOUNG_GEN_PROMOTION_RATE);
         // The policy should suggest increasing young gen when it is undersized
@@ -175,5 +179,14 @@ public class JvmGenTuningPolicyTest {
         Assert.assertEquals(1, actions.size());
         Assert.assertTrue(actions.get(0) instanceof JvmGenAction);
         Assert.assertEquals(3, ((JvmGenAction) actions.get(0)).getTargetRatio());
+        mockCurrentRatio(5);
+        actions = policy.evaluate();
+        Assert.assertEquals(1, actions.size());
+        Assert.assertTrue(actions.get(0) instanceof JvmGenAction);
+        Assert.assertEquals(4, ((JvmGenAction) actions.get(0)).getTargetRatio());
+        // Should not increase the young gen size if the ratio is not beyond 3:1
+        mockCurrentRatio(3);
+        actions = policy.evaluate();
+        Assert.assertTrue(actions.isEmpty());
     }
 }


### PR DESCRIPTION
Signoff By: Harold Xiao haoruxia@amazon.com

**Describe the solution you are proposing**
Modify the JVM gen tuning policy -> computeIncrease function to prevent increasing young gen size if the ratio is not beyond 3:1. Update the Unit test.

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
