### PR TITLE
Upgrade Jackson version to 2.11.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -288,13 +288,15 @@ dependencies {
         compile files("${System.properties['java.home']}/../lib/tools.jar")
     }
 
+    def jacksonVersion = "2.11.4"
+
     compile 'org.jooq:jooq:3.10.8'
     compile 'org.bouncycastle:bcprov-jdk15on:1.68'
     compile 'org.bouncycastle:bcpkix-jdk15on:1.68'
     compile 'org.xerial:sqlite-jdbc:3.32.3.2'
     compile 'com.google.guava:guava:28.2-jre'
-    compile 'com.fasterxml.jackson.core:jackson-annotations:2.10.5'
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.10.5.1'
+    compile "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
+    compile "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
     compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.13.0'
     compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.13.0'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
Upgrading Jackson version to match OpenSearch core and to address CVE.

**Additional context**
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-28491

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
