### PR TITLE
Replace references to /_opendistro with /_plugins

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -128,12 +128,12 @@ Once the cluster is up and running, you will need to enable Performance Analyzer
   
  1. Enable Performance Analyzer
  
-    `curl localhost:9200/_opendistro/_performanceanalyzer/cluster/config -H 'Content-Type: application/json' -d '{"enabled": true}' `
+    `curl localhost:9200/_plugins/_performanceanalyzer/cluster/config -H 'Content-Type: application/json' -d '{"enabled": true}' `
  
  2. Enable RCA Framework
  
-    `curl localhost:9200/_opendistro/_performanceanalyzer/rca/cluster/config -H 'Content-Type: application/json' -d '{"enabled": true}' `
+    `curl localhost:9200/_plugins/_performanceanalyzer/rca/cluster/config -H 'Content-Type: application/json' -d '{"enabled": true}' `
     
  3. Verify the Settings
-    `curl -XGET localhost:9200/_opendistro/_performanceanalyzer/cluster/config`. 
+    `curl -XGET localhost:9200/_plugins/_performanceanalyzer/cluster/config`. 
     It should give you `{"currentPerformanceAnalyzerClusterState":3}`

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ curl --url "localhost:9600/_plugins/_performanceanalyzer/rca" -XGET
 ```
 * To get response for a specific RCA, use:
 ```
-curl --url "localhost:9650/_plugins/_performanceanalyzer/rca?name=HighHeapUsageClusterRca" -XGET
+curl --url "localhost:9600/_plugins/_performanceanalyzer/rca?name=HighHeapUsageClusterRca" -XGET
 ```
 The sample RCA response from above api
 ```
@@ -128,7 +128,7 @@ In order to get the temperature of a particular node, we can use:
 This api returns the last suggested action set by the decider framework.
 
 ```
-curl --url "localhost:9650/_plugins/_performanceanalyzer/actions" -XGET
+curl --url "localhost:9600/_plugins/_performanceanalyzer/actions" -XGET
 ```
 
 The sample response from the above API:

--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ __Tags__: Tags are key-value pairs that are specified in the configuration file(
 ## Rest API to get the RCAs
 * To get response for all the available RCA, use:
 ```
-curl --url "localhost:9650/_opendistro/_performanceanalyzer/rca" -XGET
+curl --url "localhost:9650/_plugins/_performanceanalyzer/rca" -XGET
 ```
 * To get response for a specific RCA, use:
 ```
-curl --url "localhost:9650/_opendistro/_performanceanalyzer/rca?name=HighHeapUsageClusterRca" -XGET
+curl --url "localhost:9650/_plugins/_performanceanalyzer/rca?name=HighHeapUsageClusterRca" -XGET
 ```
 The sample RCA response from above api
 ```
@@ -117,18 +117,18 @@ There are ways to get the temperature profile of a cluster and of individual nod
 
 The cluster level RCA can only be queried from the elected master using the following rest API.
 
-`curl "localhost:9600/_opendistro/_performanceanalyzer/rca?name=ClusterTemperatureRca"`
+`curl "localhost:9600/_plugins/_performanceanalyzer/rca?name=ClusterTemperatureRca"`
 
 In order to get the temperature of a particular node, we can use:
 
-`curl "localhost:9600/_opendistro/_performanceanalyzer/rca?name=AllTemperatureDimensions&local=true"`
+`curl "localhost:9600/_plugins/_performanceanalyzer/rca?name=AllTemperatureDimensions&local=true"`
 
 ## Rest API to get the ACTIONS suggested by the decider
 
 This api returns the last suggested action set by the decider framework.
 
 ```
-curl --url "localhost:9650/_opendistro/_performanceanalyzer/actions" -XGET
+curl --url "localhost:9650/_plugins/_performanceanalyzer/actions" -XGET
 ```
 
 The sample response from the above API:

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ __Tags__: Tags are key-value pairs that are specified in the configuration file(
 ## Rest API to get the RCAs
 * To get response for all the available RCA, use:
 ```
-curl --url "localhost:9650/_plugins/_performanceanalyzer/rca" -XGET
+curl --url "localhost:9600/_plugins/_performanceanalyzer/rca" -XGET
 ```
 * To get response for a specific RCA, use:
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -581,7 +581,7 @@ def openSearchUpChecker = {
 // Attempts to enable PA for up to 2 minutes. Returns when PA is successfully enabled or
 // throws an Exception if the timeout is exceeded
 def paUpChecker = {
-    String server = "localhost:9200/_opendistro/_performanceanalyzer/cluster/config"
+    String server = "localhost:9200/_plugins/_performanceanalyzer/cluster/config"
     int timeoutSeconds = 2 * 60
     enableComponent(server, 1, timeoutSeconds)
 }
@@ -589,7 +589,7 @@ def paUpChecker = {
 // Attempts to enable RCA for up to 2 minutes. Returns when RCA is successfully enabled or
 // throws an Exception if the timeout is exceeded
 def rcaUpChecker = {
-    String server = "localhost:9200/_opendistro/_performanceanalyzer/rca/cluster/config"
+    String server = "localhost:9200/_plugins/_performanceanalyzer/rca/cluster/config"
     int timeoutSeconds = 2 * 60
     enableComponent(server, 3, timeoutSeconds)
 }
@@ -714,7 +714,7 @@ task runRally {
         while (true) {
             runCommand(opensearchrally, null, wdir, true)
             println('Get all RCAs using:')
-            println('curl localhost:9600/_opendistro/_performanceanalyzer/rca?all | python -m json.tool')
+            println('curl localhost:9600/_plugins/_performanceanalyzer/rca?all | python -m json.tool')
             Thread.sleep(1000)
         }
     }

--- a/docs/batch-metrics-api.md
+++ b/docs/batch-metrics-api.md
@@ -21,17 +21,17 @@ All the raw metrics data from a period of time may be too high granularity for s
 ## API
 
 **performance-analyzer.properties**
-* retention-period: The number of minutes worth of metrics data to collect. The configured retention period can be read via the “/_opendistro/performanceanalyzer/batch/config” api. Default=7 (7 minutes), min=1, max = 60.
+* retention-period: The number of minutes worth of metrics data to collect. The configured retention period can be read via the “/_plugins/performanceanalyzer/batch/config” api. Default=7 (7 minutes), min=1, max = 60.
   * Note, the default is 7 minutes because a typical use-case would be to query for 5 minutes worth of data from the node. In order to do this, a client would actually select a starttime of now-6min and an endtime of now-1min (this one minute offset will give sufficient time for the metrics in the time range to be available at the node). Atop this 6 minutes of retention, we need an extra 1 minute of retention to account for the time that would have passed by the time the query arrives at the node, and for the fact that starttime and endtime will be rounded down to the nearest samplingperiod.
 
 **API**
 
 Queries:
 
-* POST \<endpoint\>:9200/_opendistro/performanceanalyzer/batch/config -H ‘Content-Type: application/json’ -d ‘{“enabled”: true}’
-* POST \<endpoint\>:9200/_opendistro/performanceanalyzer/batch/cluster/config -H ‘Content-Type: application/json’ -d ‘{“enabled”: true}’
-* GET \<endpoint\>:9200/_opendistro/_performanceanalyzer/_agent/batch?metrics=\<metrics\>&starttime=\<starttime\>&endtime=\<endtime\>&samplingperiod=\<samplingperiod\>
-* GET \<endpoint\>:9600/_opendistro/_performanceanalyzer/batch?metrics=\<metrics\>&starttime=\<starttime\>&endtime=\<endtime\>&samplingperiod=\<samplingperiod\>
+* POST \<endpoint\>:9200/_plugins/performanceanalyzer/batch/config -H ‘Content-Type: application/json’ -d ‘{“enabled”: true}’
+* POST \<endpoint\>:9200/_plugins/performanceanalyzer/batch/cluster/config -H ‘Content-Type: application/json’ -d ‘{“enabled”: true}’
+* GET \<endpoint\>:9200/_plugins/_performanceanalyzer/_agent/batch?metrics=\<metrics\>&starttime=\<starttime\>&endtime=\<endtime\>&samplingperiod=\<samplingperiod\>
+* GET \<endpoint\>:9600/_plugins/_performanceanalyzer/batch?metrics=\<metrics\>&starttime=\<starttime\>&endtime=\<endtime\>&samplingperiod=\<samplingperiod\>
 
 Parameters:
 * metrics - Comma separated list of metrics you are interested in. For a full list of metrics, see Metrics Reference.
@@ -43,7 +43,7 @@ Note, the maximum number of datapoints that a single query can request for via A
 
 Sample Query:
 
-GET localhost:9600/_opendistro/_performanceanalyzer/batch?metrics=CPU_Utilization,IO_TotThroughput&starttime=1594412250000&endtime=1594412260000&samplingperiod=5
+GET localhost:9600/_plugins/_performanceanalyzer/batch?metrics=CPU_Utilization,IO_TotThroughput&starttime=1594412250000&endtime=1594412260000&samplingperiod=5
 
 Output
 ```

--- a/src/main/java/org/opensearch/performanceanalyzer/PerformanceAnalyzerApp.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/PerformanceAnalyzerApp.java
@@ -82,8 +82,8 @@ import org.opensearch.performanceanalyzer.threads.exceptions.PAThreadException;
 public class PerformanceAnalyzerApp {
 
     private static final int EXCEPTION_QUEUE_LENGTH = 1;
-    public static final String QUERY_URL = "/_opendistro/_performanceanalyzer/metrics";
-    public static final String BATCH_METRICS_URL = "/_opendistro/_performanceanalyzer/batch";
+    public static final String QUERY_URL = "/_plugins/_performanceanalyzer/metrics";
+    public static final String BATCH_METRICS_URL = "/_plugins/_performanceanalyzer/batch";
     private static final Logger LOG = LogManager.getLogger(PerformanceAnalyzerApp.class);
     private static final ScheduledMetricCollectorsExecutor METRIC_COLLECTOR_EXECUTOR =
             new ScheduledMetricCollectorsExecutor(1, false);

--- a/src/main/java/org/opensearch/performanceanalyzer/core/Util.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/core/Util.java
@@ -37,9 +37,9 @@ import org.apache.logging.log4j.message.ParameterizedMessage;
 
 public class Util {
     private static final Logger LOG = LogManager.getLogger(Util.class);
-    public static final String METRICS_QUERY_URL = "/_opendistro/_performanceanalyzer/metrics";
-    public static final String RCA_QUERY_URL = "/_opendistro/_performanceanalyzer/rca";
-    public static final String ACTIONS_QUERY_URL = "/_opendistro/_performanceanalyzer/actions";
+    public static final String METRICS_QUERY_URL = "/_plugins/_performanceanalyzer/metrics";
+    public static final String RCA_QUERY_URL = "/_plugins/_performanceanalyzer/rca";
+    public static final String ACTIONS_QUERY_URL = "/_plugins/_performanceanalyzer/actions";
     public static final String OPENSEARCH_HOME = System.getProperty("opensearch.path.home");
     public static final String PLUGIN_LOCATION =
             OPENSEARCH_HOME

--- a/src/main/java/org/opensearch/performanceanalyzer/rest/QueryActionRequestHandler.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rest/QueryActionRequestHandler.java
@@ -49,7 +49,6 @@ import org.opensearch.performanceanalyzer.rca.persistence.actions.PersistedActio
 
 /**
  * Request Handler that supports querying the latest action set
- *
  * spotless:off
  * <p>To get the response for the latest action set suggested via DM Framework curl --url
  * "localhost:9600/_plugins/_performanceanalyzer/actions" -XGET @<code>

--- a/src/main/java/org/opensearch/performanceanalyzer/rest/QueryActionRequestHandler.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rest/QueryActionRequestHandler.java
@@ -48,8 +48,7 @@ import org.opensearch.performanceanalyzer.rca.persistence.Persistable;
 import org.opensearch.performanceanalyzer.rca.persistence.actions.PersistedAction;
 
 /**
- * Request Handler that supports querying the latest action set
- * spotless:off
+ * Request Handler that supports querying the latest action set spotless:off
  * <p>To get the response for the latest action set suggested via DM Framework curl --url
  * "localhost:9600/_plugins/_performanceanalyzer/actions" -XGET @<code>
  *     {

--- a/src/main/java/org/opensearch/performanceanalyzer/rest/QueryActionRequestHandler.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rest/QueryActionRequestHandler.java
@@ -50,8 +50,9 @@ import org.opensearch.performanceanalyzer.rca.persistence.actions.PersistedActio
 /**
  * Request Handler that supports querying the latest action set
  *
+ * spotless:off
  * <p>To get the response for the latest action set suggested via DM Framework curl --url
- * "localhost:9600/_opendistro/_performanceanalyzer/actions" -XGET @<code>
+ * "localhost:9600/_plugins/_performanceanalyzer/actions" -XGET @<code>
  *     {
  *     "LastSuggestedActionSet": [
  *         {
@@ -76,6 +77,7 @@ import org.opensearch.performanceanalyzer.rca.persistence.actions.PersistedActio
  * }
  *
  * </code>
+ * spotless:on
  *
  * <p>
  */

--- a/src/main/java/org/opensearch/performanceanalyzer/rest/QueryBatchRequestHandler.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rest/QueryBatchRequestHandler.java
@@ -60,10 +60,10 @@ import org.opensearch.performanceanalyzer.reader.ReaderMetricsProcessor;
  * Request handler that supports querying batch metrics from an EC2 instance
  *
  * <p>Return 1 minute of CPU_Utilization metrics sampled at a 5s sampling period:
- * "http://localhost:9600/_opendistro/_performanceanalyzer/batch?metrics=CPU_Utilization&starttime=1566413975000&endtime=1566413980000"
+ * "http://localhost:9600/_plugins/_performanceanalyzer/batch?metrics=CPU_Utilization&starttime=1566413975000&endtime=1566413980000"
  *
  * <p>Return 1 minute of CPU_Utilization and Latency metrics sampled at a 10s sampling period:
- * "http://localhost:9600/_opendistro/_performanceanalyzer/batch?metrics=CPU_Utilization,Latency&starttime=1566413975000&endtime=1566413980000&samplingperiod=10"
+ * "http://localhost:9600/_plugins/_performanceanalyzer/batch?metrics=CPU_Utilization,Latency&starttime=1566413975000&endtime=1566413980000&samplingperiod=10"
  *
  * <p>Return format: { "1594412650000": { "CPU_Utilization": { "fields": [ { "name: "IndexName",
  * "type": "VARCHAR" }, <...> ] "records": [ [ "pmc", <...> ], <...> ] } } }

--- a/src/main/java/org/opensearch/performanceanalyzer/rest/QueryRcaRequestHandler.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rest/QueryRcaRequestHandler.java
@@ -54,13 +54,13 @@ import org.opensearch.performanceanalyzer.rca.persistence.Persistable;
  * Request handler that supports querying RCAs
  *
  * <p>To dump all RCA related tables from SQL : curl --url
- * "localhost:9650/_plugins/_performanceanalyzer/rca?all" -XGET
+ * "localhost:9600/_plugins/_performanceanalyzer/rca?all" -XGET
  *
  * <p>To get response for all the available RCA, use: curl --url
- * "localhost:9650/_plugins/_performanceanalyzer/rca" -XGET
+ * "localhost:9600/_plugins/_performanceanalyzer/rca" -XGET
  *
  * <p>To get response for a specific RCA, use: curl --url
- * "localhost:9650/_plugins/_performanceanalyzer/rca?name=HighHeapUsageClusterRca" -XGET
+ * "localhost:9600/_plugins/_performanceanalyzer/rca?name=HighHeapUsageClusterRca" -XGET
  *
  * <p>For temperature profiles, one can get the local node temperature using a request url as: curl
  * "localhost:9600/_plugins/_performanceanalyzer/rca?name=NodeTemperatureRca&local=true"

--- a/src/main/java/org/opensearch/performanceanalyzer/rest/QueryRcaRequestHandler.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rest/QueryRcaRequestHandler.java
@@ -54,22 +54,22 @@ import org.opensearch.performanceanalyzer.rca.persistence.Persistable;
  * Request handler that supports querying RCAs
  *
  * <p>To dump all RCA related tables from SQL : curl --url
- * "localhost:9650/_opendistro/_performanceanalyzer/rca?all" -XGET
+ * "localhost:9650/_plugins/_performanceanalyzer/rca?all" -XGET
  *
  * <p>To get response for all the available RCA, use: curl --url
- * "localhost:9650/_opendistro/_performanceanalyzer/rca" -XGET
+ * "localhost:9650/_plugins/_performanceanalyzer/rca" -XGET
  *
  * <p>To get response for a specific RCA, use: curl --url
- * "localhost:9650/_opendistro/_performanceanalyzer/rca?name=HighHeapUsageClusterRca" -XGET
+ * "localhost:9650/_plugins/_performanceanalyzer/rca?name=HighHeapUsageClusterRca" -XGET
  *
  * <p>For temperature profiles, one can get the local node temperature using a request url as: curl
- * "localhost:9600/_opendistro/_performanceanalyzer/rca?name=NodeTemperatureRca&local=true"
+ * "localhost:9600/_plugins/_performanceanalyzer/rca?name=NodeTemperatureRca&local=true"
  *
  * <p>The cluster level RCA can only be queried from the elected master using this rest API: curl
- * "localhost:9600/_opendistro/_performanceanalyzer/rca?name=ClusterTemperatureRca"
+ * "localhost:9600/_plugins/_performanceanalyzer/rca?name=ClusterTemperatureRca"
  *
  * <p>curl
- * "localhost:9600/_opendistro/_performanceanalyzer/rca?name=NodeTemperatureRca&local=true"|jq {
+ * "localhost:9600/_plugins/_performanceanalyzer/rca?name=NodeTemperatureRca&local=true"|jq {
  * "NodeTemperatureRca": [ { "rca_name": "NodeTemperatureRca", "timestamp": 1589592178829, "state":
  * "unknown", "CompactNodeSummary": [ { "node_id": "v9_TNhEeSP2Q3DJO8fd6BA", "host_address":
  * "172.17.0.2", "CPU_Utilization_mean": 0, "CPU_Utilization_total": 0.0310837676896351,

--- a/src/main/java/org/opensearch/performanceanalyzer/rest/QueryRcaRequestHandler.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rest/QueryRcaRequestHandler.java
@@ -68,16 +68,15 @@ import org.opensearch.performanceanalyzer.rca.persistence.Persistable;
  * <p>The cluster level RCA can only be queried from the elected master using this rest API: curl
  * "localhost:9600/_plugins/_performanceanalyzer/rca?name=ClusterTemperatureRca"
  *
- * <p>curl
- * "localhost:9600/_plugins/_performanceanalyzer/rca?name=NodeTemperatureRca&local=true"|jq {
- * "NodeTemperatureRca": [ { "rca_name": "NodeTemperatureRca", "timestamp": 1589592178829, "state":
- * "unknown", "CompactNodeSummary": [ { "node_id": "v9_TNhEeSP2Q3DJO8fd6BA", "host_address":
- * "172.17.0.2", "CPU_Utilization_mean": 0, "CPU_Utilization_total": 0.0310837676896351,
- * "CPU_Utilization_num_shards": 2, "Heap_AllocRate_mean": 0, "Heap_AllocRate_total":
- * 4021355.87442904, "Heap_AllocRate_num_shards": 2, "IO_READ_SYSCALL_RATE_mean": 0,
- * "IO_READ_SYSCALL_RATE_total": 0, "IO_READ_SYSCALL_RATE_num_shards": 0,
- * "IO_WriteSyscallRate_mean": 0, "IO_WriteSyscallRate_total": 0, "IO_WriteSyscallRate_num_shards":
- * 0 } ] } ] }
+ * <p>curl "localhost:9600/_plugins/_performanceanalyzer/rca?name=NodeTemperatureRca&local=true"|jq
+ * { "NodeTemperatureRca": [ { "rca_name": "NodeTemperatureRca", "timestamp": 1589592178829,
+ * "state": "unknown", "CompactNodeSummary": [ { "node_id": "v9_TNhEeSP2Q3DJO8fd6BA",
+ * "host_address": "172.17.0.2", "CPU_Utilization_mean": 0, "CPU_Utilization_total":
+ * 0.0310837676896351, "CPU_Utilization_num_shards": 2, "Heap_AllocRate_mean": 0,
+ * "Heap_AllocRate_total": 4021355.87442904, "Heap_AllocRate_num_shards": 2,
+ * "IO_READ_SYSCALL_RATE_mean": 0, "IO_READ_SYSCALL_RATE_total": 0,
+ * "IO_READ_SYSCALL_RATE_num_shards": 0, "IO_WriteSyscallRate_mean": 0, "IO_WriteSyscallRate_total":
+ * 0, "IO_WriteSyscallRate_num_shards": 0 } ] } ] }
  */
 public class QueryRcaRequestHandler extends MetricsHandler implements HttpHandler {
 

--- a/src/test/java/org/opensearch/performanceanalyzer/rest/QueryBatchRequestHandlerTest.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/rest/QueryBatchRequestHandlerTest.java
@@ -74,7 +74,7 @@ public class QueryBatchRequestHandlerTest {
         handler = new QueryBatchRequestHandler(null, new MetricsRestUtil());
         rootLocation = "build/resources/test/reader/";
         setBatchMetricsEnabled(false);
-        queryPrefix = "http://localhost:9600/_opendistro/_performanceanalyzer/batch?";
+        queryPrefix = "http://localhost:9600/_plugins/_performanceanalyzer/batch?";
         timestamp = 1566413970000L;
     }
 


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
Updating calls to the Performance Analyzer plugin API to follow the new `/_plugins` naming convention.

**Describe the solution you are proposing**
RCA behavior should be unchanged.

**Describe alternatives you've considered**
This is a required change to follow new OpenSearch guidelines.

**Additional context**
https://github.com/opensearch-project/opensearch-plugins/blob/main/UPGRADING.md#settings-backwards-compatibility

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
