### PR TITLE
Create HTTP contexts for legacy resource name

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/PerformanceAnalyzerApp.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/PerformanceAnalyzerApp.java
@@ -83,9 +83,11 @@ public class PerformanceAnalyzerApp {
 
     private static final int EXCEPTION_QUEUE_LENGTH = 1;
     public static final String QUERY_URL = "/_plugins/_performanceanalyzer/metrics";
-    public static final String LEGACY_QUERY_URL = "/_opendistro/_performanceanalyzer/metrics";
+    public static final String LEGACY_OPENDISTRO_QUERY_URL =
+            "/_opendistro/_performanceanalyzer/metrics";
     public static final String BATCH_METRICS_URL = "/_plugins/_performanceanalyzer/batch";
-    public static final String LEGACY_BATCH_METRICS_URL = "/_opendistro/_performanceanalyzer/batch";
+    public static final String LEGACY_OPENDISTRO_BATCH_METRICS_URL =
+            "/_opendistro/_performanceanalyzer/batch";
     private static final Logger LOG = LogManager.getLogger(PerformanceAnalyzerApp.class);
     private static final ScheduledMetricCollectorsExecutor METRIC_COLLECTOR_EXECUTOR =
             new ScheduledMetricCollectorsExecutor(1, false);
@@ -352,12 +354,12 @@ public class PerformanceAnalyzerApp {
             QueryMetricsRequestHandler queryMetricsRequestHandler =
                     new QueryMetricsRequestHandler(netClient, metricsRestUtil, appContext);
             httpServer.createContext(QUERY_URL, queryMetricsRequestHandler);
-            httpServer.createContext(LEGACY_QUERY_URL, queryMetricsRequestHandler);
+            httpServer.createContext(LEGACY_OPENDISTRO_QUERY_URL, queryMetricsRequestHandler);
 
             QueryBatchRequestHandler queryBatchRequestHandler =
                     new QueryBatchRequestHandler(netClient, metricsRestUtil);
             httpServer.createContext(BATCH_METRICS_URL, queryBatchRequestHandler);
-            httpServer.createContext(LEGACY_BATCH_METRICS_URL, queryBatchRequestHandler);
+            httpServer.createContext(LEGACY_OPENDISTRO_BATCH_METRICS_URL, queryBatchRequestHandler);
         }
 
         return new ClientServers(httpServer, netServer, netClient);

--- a/src/main/java/org/opensearch/performanceanalyzer/PerformanceAnalyzerApp.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/PerformanceAnalyzerApp.java
@@ -83,7 +83,9 @@ public class PerformanceAnalyzerApp {
 
     private static final int EXCEPTION_QUEUE_LENGTH = 1;
     public static final String QUERY_URL = "/_plugins/_performanceanalyzer/metrics";
+    public static final String LEGACY_QUERY_URL = "/_opendistro/_performanceanalyzer/metrics";
     public static final String BATCH_METRICS_URL = "/_plugins/_performanceanalyzer/batch";
+    public static final String LEGACY_BATCH_METRICS_URL = "/_opendistro/_performanceanalyzer/batch";
     private static final Logger LOG = LogManager.getLogger(PerformanceAnalyzerApp.class);
     private static final ScheduledMetricCollectorsExecutor METRIC_COLLECTOR_EXECUTOR =
             new ScheduledMetricCollectorsExecutor(1, false);
@@ -347,11 +349,15 @@ public class PerformanceAnalyzerApp {
                         webServerPort, hostFromSetting, useHttps);
 
         if (metricsRestUtil != null) {
-            httpServer.createContext(
-                    QUERY_URL,
-                    new QueryMetricsRequestHandler(netClient, metricsRestUtil, appContext));
-            httpServer.createContext(
-                    BATCH_METRICS_URL, new QueryBatchRequestHandler(netClient, metricsRestUtil));
+            QueryMetricsRequestHandler queryMetricsRequestHandler =
+                    new QueryMetricsRequestHandler(netClient, metricsRestUtil, appContext);
+            httpServer.createContext(QUERY_URL, queryMetricsRequestHandler);
+            httpServer.createContext(LEGACY_QUERY_URL, queryMetricsRequestHandler);
+
+            QueryBatchRequestHandler queryBatchRequestHandler =
+                    new QueryBatchRequestHandler(netClient, metricsRestUtil);
+            httpServer.createContext(BATCH_METRICS_URL, queryBatchRequestHandler);
+            httpServer.createContext(LEGACY_BATCH_METRICS_URL, queryBatchRequestHandler);
         }
 
         return new ClientServers(httpServer, netServer, netClient);


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
We want the Performance Analyzer agent API for OpenSearch to be backward compatible with OpenDistro.

**Describe the solution you are proposing**
Adding HttpContexts that will resolve the old `/_opendistro` resource name.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
