### PR TITLE
Update docker artifact to track latest

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,7 +49,7 @@ WORKDIR /usr/share/opensearch
 ENV BUST_CACHE 1576286189
 
 # Download and extract defined OpenSearch version.
-RUN curl -fsSL https://artifacts.opensearch.org/releases/core/opensearch/1.0.0-rc1/opensearch-1.0.0-rc1-linux-x64.tar.gz | \
+RUN curl -fsSL https://artifacts.opensearch.org/snapshots/core/opensearch/1.0.0-SNAPSHOT/opensearch-min-1.0.0-SNAPSHOT-linux-arm64-latest.tar.gz | \
     tar zx --strip-components=1
 
 RUN set -ex && for opensearchdirs in config data logs; do \


### PR DESCRIPTION
Signed-off-by: Sruti Parthiban <partsrut@amazon.com>

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

**Describe the solution you are proposing**
Update docker artifact to track latest

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
```
> Task :integTest

org.opensearch.performanceanalyzer.integ_test.HeapMetricsIT > checkHeapInit STANDARD_OUT
    [2021-07-01T20:45:07,819][INFO ][o.o.p.i.HeapMetricsIT    ] [checkHeapInit] before test
    [2021-07-01T20:45:08,186][INFO ][o.o.p.i.HeapMetricsIT    ] [checkHeapInit] initializing REST clients against [http://localhost:9200]
    [2021-07-01T20:45:09,320][INFO ][o.o.p.i.HeapMetricsIT    ] [checkHeapInit] Cluster is localhost:9200
    [2021-07-01T20:45:09,321][INFO ][o.o.p.i.HeapMetricsIT    ] [checkHeapInit] initializing PerformanceAnalyzer client against [http://localhost:9600]
    [2021-07-01T20:45:09,887][INFO ][o.o.p.i.HeapMetricsIT    ] [checkHeapInit] Heap_Init value is 512.0
    [2021-07-01T20:45:09,939][INFO ][o.o.p.i.HeapMetricsIT    ] [checkHeapInit] Heap_Init value is 512.0
    [2021-07-01T20:45:09,939][INFO ][o.o.p.i.HeapMetricsIT    ] [checkHeapInit] Heap_Init value is 512.0
    [2021-07-01T20:45:10,020][INFO ][o.o.p.i.HeapMetricsIT    ] [checkHeapInit] after test

org.opensearch.performanceanalyzer.integ_test.HeapMetricsIT > checkHeapUsed STANDARD_OUT
    [2021-07-01T20:45:10,107][INFO ][o.o.p.i.HeapMetricsIT    ] [checkHeapUsed] before test
    [2021-07-01T20:45:10,109][INFO ][o.o.p.i.HeapMetricsIT    ] [checkHeapUsed] initializing REST clients against [http://localhost:9200]
    [2021-07-01T20:45:10,159][INFO ][o.o.p.i.HeapMetricsIT    ] [checkHeapUsed] Cluster is localhost:9200
    [2021-07-01T20:45:10,159][INFO ][o.o.p.i.HeapMetricsIT    ] [checkHeapUsed] initializing PerformanceAnalyzer client against [http://localhost:9600]
    [2021-07-01T20:45:10,216][INFO ][o.o.p.i.HeapMetricsIT    ] [checkHeapUsed] Heap_Used value is 94.49047088623047
    [2021-07-01T20:45:10,323][INFO ][o.o.p.i.HeapMetricsIT    ] [checkHeapUsed] Heap_Used value is 175.1578140258789
    [2021-07-01T20:45:10,324][INFO ][o.o.p.i.HeapMetricsIT    ] [checkHeapUsed] Heap_Used value is 94.49047088623047
    [2021-07-01T20:45:10,327][INFO ][o.o.p.i.HeapMetricsIT    ] [checkHeapUsed] after test

org.opensearch.performanceanalyzer.integ_test.HeapMetricsIT > checkHeapMax STANDARD_OUT
    [2021-07-01T20:45:10,336][INFO ][o.o.p.i.HeapMetricsIT    ] [checkHeapMax] before test
    [2021-07-01T20:45:10,337][INFO ][o.o.p.i.HeapMetricsIT    ] [checkHeapMax] initializing REST clients against [http://localhost:9200]
    [2021-07-01T20:45:10,444][INFO ][o.o.p.i.HeapMetricsIT    ] [checkHeapMax] Cluster is localhost:9200
    [2021-07-01T20:45:10,445][INFO ][o.o.p.i.HeapMetricsIT    ] [checkHeapMax] initializing PerformanceAnalyzer client against [http://localhost:9600]
    [2021-07-01T20:45:10,558][INFO ][o.o.p.i.HeapMetricsIT    ] [checkHeapMax] Heap_Max value is 495.375
    [2021-07-01T20:45:10,779][INFO ][o.o.p.i.HeapMetricsIT    ] [checkHeapMax] Heap_Max value is 495.375
    [2021-07-01T20:45:10,780][INFO ][o.o.p.i.HeapMetricsIT    ] [checkHeapMax] Heap_Max value is 495.375
    [2021-07-01T20:45:10,783][INFO ][o.o.p.i.HeapMetricsIT    ] [checkHeapMax] after test

org.opensearch.performanceanalyzer.integ_test.HeapMetricsIT > checkLegacyHeapUsed STANDARD_OUT
    [2021-07-01T20:45:10,800][INFO ][o.o.p.i.HeapMetricsIT    ] [checkLegacyHeapUsed] before test
    [2021-07-01T20:45:10,802][INFO ][o.o.p.i.HeapMetricsIT    ] [checkLegacyHeapUsed] initializing REST clients against [http://localhost:9200]
    [2021-07-01T20:45:10,875][INFO ][o.o.p.i.HeapMetricsIT    ] [checkLegacyHeapUsed] Cluster is localhost:9200
    [2021-07-01T20:45:10,876][INFO ][o.o.p.i.HeapMetricsIT    ] [checkLegacyHeapUsed] initializing PerformanceAnalyzer client against [http://localhost:9600]
    [2021-07-01T20:45:10,955][INFO ][o.o.p.i.HeapMetricsIT    ] [checkLegacyHeapUsed] Heap_Used value is 94.49047088623047
    [2021-07-01T20:45:11,141][INFO ][o.o.p.i.HeapMetricsIT    ] [checkLegacyHeapUsed] Heap_Used value is 175.1578140258789
    [2021-07-01T20:45:11,141][INFO ][o.o.p.i.HeapMetricsIT    ] [checkLegacyHeapUsed] Heap_Used value is 94.49047088623047
    [2021-07-01T20:45:11,144][INFO ][o.o.p.i.HeapMetricsIT    ] [checkLegacyHeapUsed] after test

org.opensearch.performanceanalyzer.integ_test.HeapMetricsIT > checkLegacyHeapMax STANDARD_OUT
    [2021-07-01T20:45:11,155][INFO ][o.o.p.i.HeapMetricsIT    ] [checkLegacyHeapMax] before test
    [2021-07-01T20:45:11,156][INFO ][o.o.p.i.HeapMetricsIT    ] [checkLegacyHeapMax] initializing REST clients against [http://localhost:9200]
    [2021-07-01T20:45:11,244][INFO ][o.o.p.i.HeapMetricsIT    ] [checkLegacyHeapMax] Cluster is localhost:9200
    [2021-07-01T20:45:11,244][INFO ][o.o.p.i.HeapMetricsIT    ] [checkLegacyHeapMax] initializing PerformanceAnalyzer client against [http://localhost:9600]
    [2021-07-01T20:45:11,367][INFO ][o.o.p.i.HeapMetricsIT    ] [checkLegacyHeapMax] Heap_Max value is 495.375
    [2021-07-01T20:45:11,772][INFO ][o.o.p.i.HeapMetricsIT    ] [checkLegacyHeapMax] Heap_Max value is 495.375
    [2021-07-01T20:45:11,773][INFO ][o.o.p.i.HeapMetricsIT    ] [checkLegacyHeapMax] Heap_Max value is 495.375
    [2021-07-01T20:45:11,776][INFO ][o.o.p.i.HeapMetricsIT    ] [checkLegacyHeapMax] after test

org.opensearch.performanceanalyzer.integ_test.HeapMetricsIT > checkLegacyHeapInit STANDARD_OUT
    [2021-07-01T20:45:11,783][INFO ][o.o.p.i.HeapMetricsIT    ] [checkLegacyHeapInit] before test
    [2021-07-01T20:45:11,784][INFO ][o.o.p.i.HeapMetricsIT    ] [checkLegacyHeapInit] initializing REST clients against [http://localhost:9200]
    [2021-07-01T20:45:11,845][INFO ][o.o.p.i.HeapMetricsIT    ] [checkLegacyHeapInit] Cluster is localhost:9200
    [2021-07-01T20:45:11,845][INFO ][o.o.p.i.HeapMetricsIT    ] [checkLegacyHeapInit] initializing PerformanceAnalyzer client against [http://localhost:9600]
    [2021-07-01T20:45:12,011][INFO ][o.o.p.i.HeapMetricsIT    ] [checkLegacyHeapInit] Heap_Init value is 512.0
    [2021-07-01T20:45:12,172][INFO ][o.o.p.i.HeapMetricsIT    ] [checkLegacyHeapInit] Heap_Init value is 512.0
    [2021-07-01T20:45:12,173][INFO ][o.o.p.i.HeapMetricsIT    ] [checkLegacyHeapInit] Heap_Init value is 512.0
    [2021-07-01T20:45:12,175][INFO ][o.o.p.i.HeapMetricsIT    ] [checkLegacyHeapInit] after test

org.opensearch.performanceanalyzer.integ_test.CpuMetricsIT > checkLegacyCPUUtilization STANDARD_OUT
    [2021-07-01T15:45:12,305][INFO ][o.o.p.i.CpuMetricsIT     ] [checkLegacyCPUUtilization] before test
    [2021-07-01T15:45:12,311][INFO ][o.o.p.i.CpuMetricsIT     ] [checkLegacyCPUUtilization] initializing REST clients against [http://localhost:9200]
    [2021-07-01T15:45:12,349][INFO ][o.o.p.i.CpuMetricsIT     ] [checkLegacyCPUUtilization] Cluster is localhost:9200
    [2021-07-01T15:45:12,349][INFO ][o.o.p.i.CpuMetricsIT     ] [checkLegacyCPUUtilization] initializing PerformanceAnalyzer client against [http://localhost:9600]
    [2021-07-01T15:45:12,471][INFO ][o.o.p.i.CpuMetricsIT     ] [checkLegacyCPUUtilization] after test

org.opensearch.performanceanalyzer.integ_test.CpuMetricsIT > checkCPUUtilization STANDARD_OUT
    [2021-07-01T15:45:12,494][INFO ][o.o.p.i.CpuMetricsIT     ] [checkCPUUtilization] before test
    [2021-07-01T15:45:12,495][INFO ][o.o.p.i.CpuMetricsIT     ] [checkCPUUtilization] initializing REST clients against [http://localhost:9200]
    [2021-07-01T15:45:12,549][INFO ][o.o.p.i.CpuMetricsIT     ] [checkCPUUtilization] Cluster is localhost:9200
    [2021-07-01T15:45:12,550][INFO ][o.o.p.i.CpuMetricsIT     ] [checkCPUUtilization] initializing PerformanceAnalyzer client against [http://localhost:9600]
    [2021-07-01T15:45:12,741][INFO ][o.o.p.i.CpuMetricsIT     ] [checkCPUUtilization] after test

org.opensearch.performanceanalyzer.integ_test.PageFaultMetricsIT > checkLegacyPaging_MajfltRate STANDARD_OUT
    [2021-07-01T16:45:12,810][INFO ][o.o.p.i.PageFaultMetricsIT] [checkLegacyPaging_MajfltRate] before test
    [2021-07-01T16:45:12,815][INFO ][o.o.p.i.PageFaultMetricsIT] [checkLegacyPaging_MajfltRate] initializing REST clients against [http://localhost:9200]
    [2021-07-01T16:45:12,842][INFO ][o.o.p.i.PageFaultMetricsIT] [checkLegacyPaging_MajfltRate] Cluster is localhost:9200
    [2021-07-01T16:45:12,843][INFO ][o.o.p.i.PageFaultMetricsIT] [checkLegacyPaging_MajfltRate] initializing PerformanceAnalyzer client against [http://localhost:9600]
    [2021-07-01T16:45:12,978][INFO ][o.o.p.i.PageFaultMetricsIT] [checkLegacyPaging_MajfltRate] after test

org.opensearch.performanceanalyzer.integ_test.PageFaultMetricsIT > checkLegacyPaging_RSS STANDARD_OUT
    [2021-07-01T16:45:12,985][INFO ][o.o.p.i.PageFaultMetricsIT] [checkLegacyPaging_RSS] before test
    [2021-07-01T16:45:12,986][INFO ][o.o.p.i.PageFaultMetricsIT] [checkLegacyPaging_RSS] initializing REST clients against [http://localhost:9200]
    [2021-07-01T16:45:13,015][INFO ][o.o.p.i.PageFaultMetricsIT] [checkLegacyPaging_RSS] Cluster is localhost:9200
    [2021-07-01T16:45:13,015][INFO ][o.o.p.i.PageFaultMetricsIT] [checkLegacyPaging_RSS] initializing PerformanceAnalyzer client against [http://localhost:9600]
    [2021-07-01T16:45:13,230][INFO ][o.o.p.i.PageFaultMetricsIT] [checkLegacyPaging_RSS] after test

org.opensearch.performanceanalyzer.integ_test.PageFaultMetricsIT > checkLegacyPaging_MinfltRate STANDARD_OUT
    [2021-07-01T16:45:13,238][INFO ][o.o.p.i.PageFaultMetricsIT] [checkLegacyPaging_MinfltRate] before test
    [2021-07-01T16:45:13,239][INFO ][o.o.p.i.PageFaultMetricsIT] [checkLegacyPaging_MinfltRate] initializing REST clients against [http://localhost:9200]
    [2021-07-01T16:45:13,262][INFO ][o.o.p.i.PageFaultMetricsIT] [checkLegacyPaging_MinfltRate] Cluster is localhost:9200
    [2021-07-01T16:45:13,263][INFO ][o.o.p.i.PageFaultMetricsIT] [checkLegacyPaging_MinfltRate] initializing PerformanceAnalyzer client against [http://localhost:9600]
    [2021-07-01T16:45:13,384][INFO ][o.o.p.i.PageFaultMetricsIT] [checkLegacyPaging_MinfltRate] after test

org.opensearch.performanceanalyzer.integ_test.PageFaultMetricsIT > checkPaging_RSS STANDARD_OUT
    [2021-07-01T16:45:13,391][INFO ][o.o.p.i.PageFaultMetricsIT] [checkPaging_RSS] before test
    [2021-07-01T16:45:13,392][INFO ][o.o.p.i.PageFaultMetricsIT] [checkPaging_RSS] initializing REST clients against [http://localhost:9200]
    [2021-07-01T16:45:13,414][INFO ][o.o.p.i.PageFaultMetricsIT] [checkPaging_RSS] Cluster is localhost:9200
    [2021-07-01T16:45:13,415][INFO ][o.o.p.i.PageFaultMetricsIT] [checkPaging_RSS] initializing PerformanceAnalyzer client against [http://localhost:9600]
    [2021-07-01T16:45:13,524][INFO ][o.o.p.i.PageFaultMetricsIT] [checkPaging_RSS] after test

org.opensearch.performanceanalyzer.integ_test.PageFaultMetricsIT > checkPaging_MinfltRate STANDARD_OUT
    [2021-07-01T16:45:13,531][INFO ][o.o.p.i.PageFaultMetricsIT] [checkPaging_MinfltRate] before test
    [2021-07-01T16:45:13,533][INFO ][o.o.p.i.PageFaultMetricsIT] [checkPaging_MinfltRate] initializing REST clients against [http://localhost:9200]
    [2021-07-01T16:45:13,554][INFO ][o.o.p.i.PageFaultMetricsIT] [checkPaging_MinfltRate] Cluster is localhost:9200
    [2021-07-01T16:45:13,555][INFO ][o.o.p.i.PageFaultMetricsIT] [checkPaging_MinfltRate] initializing PerformanceAnalyzer client against [http://localhost:9600]
    [2021-07-01T16:45:13,677][INFO ][o.o.p.i.PageFaultMetricsIT] [checkPaging_MinfltRate] after test

org.opensearch.performanceanalyzer.integ_test.PageFaultMetricsIT > checkPaging_MajfltRate STANDARD_OUT
    [2021-07-01T16:45:13,685][INFO ][o.o.p.i.PageFaultMetricsIT] [checkPaging_MajfltRate] before test
    [2021-07-01T16:45:13,685][INFO ][o.o.p.i.PageFaultMetricsIT] [checkPaging_MajfltRate] initializing REST clients against [http://localhost:9200]
    [2021-07-01T16:45:13,706][INFO ][o.o.p.i.PageFaultMetricsIT] [checkPaging_MajfltRate] Cluster is localhost:9200
    [2021-07-01T16:45:13,707][INFO ][o.o.p.i.PageFaultMetricsIT] [checkPaging_MajfltRate] initializing PerformanceAnalyzer client against [http://localhost:9600]
    [2021-07-01T16:45:13,834][INFO ][o.o.p.i.PageFaultMetricsIT] [checkPaging_MajfltRate] after test

org.opensearch.performanceanalyzer.ConfigOverridesIT > testSimpleOverride STANDARD_OUT
    [2021-07-01T15:45:13,917][INFO ][o.o.p.ConfigOverridesIT  ] [testSimpleOverride] before test
    [2021-07-01T15:45:13,926][INFO ][o.o.p.ConfigOverridesIT  ] [testSimpleOverride] initializing REST clients against [http://localhost:9200]
    [2021-07-01T15:45:13,947][INFO ][o.o.p.ConfigOverridesIT  ] [testSimpleOverride] Cluster is localhost:9200
    [2021-07-01T15:45:13,948][INFO ][o.o.p.ConfigOverridesIT  ] [testSimpleOverride] initializing PerformanceAnalyzer client against [http://localhost:9600]
    [2021-07-01T15:45:15,096][INFO ][o.o.p.ConfigOverridesIT  ] [testSimpleOverride] after test

org.opensearch.performanceanalyzer.ConfigOverridesIT > testLegacyCompositeOverrides STANDARD_OUT
    [2021-07-01T15:45:15,105][INFO ][o.o.p.ConfigOverridesIT  ] [testLegacyCompositeOverrides] before test
    [2021-07-01T15:45:15,107][INFO ][o.o.p.ConfigOverridesIT  ] [testLegacyCompositeOverrides] initializing REST clients against [http://localhost:9200]
    [2021-07-01T15:45:15,143][INFO ][o.o.p.ConfigOverridesIT  ] [testLegacyCompositeOverrides] Cluster is localhost:9200
    [2021-07-01T15:45:15,144][INFO ][o.o.p.ConfigOverridesIT  ] [testLegacyCompositeOverrides] initializing PerformanceAnalyzer client against [http://localhost:9600]
    [2021-07-01T15:45:15,484][INFO ][o.o.p.ConfigOverridesIT  ] [testLegacyCompositeOverrides] after test

org.opensearch.performanceanalyzer.ConfigOverridesIT > testLegacySimpleOverride STANDARD_OUT
    [2021-07-01T15:45:15,491][INFO ][o.o.p.ConfigOverridesIT  ] [testLegacySimpleOverride] before test
    [2021-07-01T15:45:15,492][INFO ][o.o.p.ConfigOverridesIT  ] [testLegacySimpleOverride] initializing REST clients against [http://localhost:9200]
    [2021-07-01T15:45:15,518][INFO ][o.o.p.ConfigOverridesIT  ] [testLegacySimpleOverride] Cluster is localhost:9200
    [2021-07-01T15:45:15,518][INFO ][o.o.p.ConfigOverridesIT  ] [testLegacySimpleOverride] initializing PerformanceAnalyzer client against [http://localhost:9600]
    [2021-07-01T15:45:15,795][INFO ][o.o.p.ConfigOverridesIT  ] [testLegacySimpleOverride] after test

org.opensearch.performanceanalyzer.ConfigOverridesIT > testCompositeOverrides STANDARD_OUT
    [2021-07-01T15:45:15,799][INFO ][o.o.p.ConfigOverridesIT  ] [testCompositeOverrides] before test
    [2021-07-01T15:45:15,800][INFO ][o.o.p.ConfigOverridesIT  ] [testCompositeOverrides] initializing REST clients against [http://localhost:9200]
    [2021-07-01T15:45:15,867][INFO ][o.o.p.ConfigOverridesIT  ] [testCompositeOverrides] Cluster is localhost:9200
    [2021-07-01T15:45:15,867][INFO ][o.o.p.ConfigOverridesIT  ] [testCompositeOverrides] initializing PerformanceAnalyzer client against [http://localhost:9600]
    [2021-07-01T15:45:16,130][INFO ][o.o.p.ConfigOverridesIT  ] [testCompositeOverrides] after test

org.opensearch.performanceanalyzer.PerformanceAnalyzerRCAHealthCheckIT > testRcaIsRunning STANDARD_OUT
    [2021-07-02T00:45:16,181][INFO ][o.o.p.PerformanceAnalyzerRCAHealthCheckIT] [testRcaIsRunning] before test
    [2021-07-02T00:45:16,182][INFO ][o.o.p.PerformanceAnalyzerRCAHealthCheckIT] [testRcaIsRunning] initializing REST clients against [http://localhost:9200]
    [2021-07-02T00:45:16,228][INFO ][o.o.p.PerformanceAnalyzerRCAHealthCheckIT] [testRcaIsRunning] Cluster is localhost:9200
    [2021-07-02T00:45:16,228][INFO ][o.o.p.PerformanceAnalyzerRCAHealthCheckIT] [testRcaIsRunning] initializing PerformanceAnalyzer client against [http://localhost:9600]
    [2021-07-02T00:45:16,572][INFO ][o.o.p.PerformanceAnalyzerRCAHealthCheckIT] [testRcaIsRunning] after test

org.opensearch.performanceanalyzer.PerformanceAnalyzerRCAHealthCheckIT > checkMetrics STANDARD_OUT
    [2021-07-02T00:45:16,577][INFO ][o.o.p.PerformanceAnalyzerRCAHealthCheckIT] [checkMetrics] before test
    [2021-07-02T00:45:16,577][INFO ][o.o.p.PerformanceAnalyzerRCAHealthCheckIT] [checkMetrics] initializing REST clients against [http://localhost:9200]
    [2021-07-02T00:45:16,620][INFO ][o.o.p.PerformanceAnalyzerRCAHealthCheckIT] [checkMetrics] Cluster is localhost:9200
    [2021-07-02T00:45:16,620][INFO ][o.o.p.PerformanceAnalyzerRCAHealthCheckIT] [checkMetrics] initializing PerformanceAnalyzer client against [http://localhost:9600]
    [2021-07-02T00:45:16,709][INFO ][o.o.p.PerformanceAnalyzerRCAHealthCheckIT] [checkMetrics] jsonString is {"1AFdUyHWTrqJAhZ-UKrFTQ": {"timestamp": 1625179495000, "data": {"fields":[{"name":"Disk_Utilization","type":"DOUBLE"}],"records":[[0.04418232706917233]]}}, "pKamjXd4Qwy7hXYra-_kyA" :{"timestamp": 1625179495000, "data": {"fields":[{"name":"Disk_Utilization","type":"DOUBLE"}],"records":[[0.04409417398244214]]}}}
    [2021-07-02T00:45:16,712][INFO ][o.o.p.PerformanceAnalyzerRCAHealthCheckIT] [checkMetrics] after test

org.opensearch.performanceanalyzer.PerformanceAnalyzerRCAHealthCheckIT > testLegacyRcaIsRunning STANDARD_OUT
    [2021-07-02T00:45:16,717][INFO ][o.o.p.PerformanceAnalyzerRCAHealthCheckIT] [testLegacyRcaIsRunning] before test
    [2021-07-02T00:45:16,718][INFO ][o.o.p.PerformanceAnalyzerRCAHealthCheckIT] [testLegacyRcaIsRunning] initializing REST clients against [http://localhost:9200]
    [2021-07-02T00:45:16,738][INFO ][o.o.p.PerformanceAnalyzerRCAHealthCheckIT] [testLegacyRcaIsRunning] Cluster is localhost:9200
    [2021-07-02T00:45:16,738][INFO ][o.o.p.PerformanceAnalyzerRCAHealthCheckIT] [testLegacyRcaIsRunning] initializing PerformanceAnalyzer client against [http://localhost:9600]
    [2021-07-02T00:45:16,804][INFO ][o.o.p.PerformanceAnalyzerRCAHealthCheckIT] [testLegacyRcaIsRunning] after test

org.opensearch.performanceanalyzer.PerformanceAnalyzerRCAHealthCheckIT > checkLegacyMetrics STANDARD_OUT
    [2021-07-02T00:45:16,810][INFO ][o.o.p.PerformanceAnalyzerRCAHealthCheckIT] [checkLegacyMetrics] before test
    [2021-07-02T00:45:16,810][INFO ][o.o.p.PerformanceAnalyzerRCAHealthCheckIT] [checkLegacyMetrics] initializing REST clients against [http://localhost:9200]
    [2021-07-02T00:45:16,835][INFO ][o.o.p.PerformanceAnalyzerRCAHealthCheckIT] [checkLegacyMetrics] Cluster is localhost:9200
    [2021-07-02T00:45:16,836][INFO ][o.o.p.PerformanceAnalyzerRCAHealthCheckIT] [checkLegacyMetrics] initializing PerformanceAnalyzer client against [http://localhost:9600]
    [2021-07-02T00:45:16,928][INFO ][o.o.p.PerformanceAnalyzerRCAHealthCheckIT] [checkLegacyMetrics] jsonString is {"1AFdUyHWTrqJAhZ-UKrFTQ": {"timestamp": 1625179495000, "data": {"fields":[{"name":"Disk_Utilization","type":"DOUBLE"}],"records":[[0.04418232706917233]]}}, "pKamjXd4Qwy7hXYra-_kyA" :{"timestamp": 1625179495000, "data": {"fields":[{"name":"Disk_Utilization","type":"DOUBLE"}],"records":[[0.04409417398244214]]}}}
    [2021-07-02T00:45:16,931][INFO ][o.o.p.PerformanceAnalyzerRCAHealthCheckIT] [checkLegacyMetrics] after test

Gradle Test Executor 1 finished executing tests.

> Task :integTest
Finished generating test XML results (0.019 secs) into: /Users/partsrut/Desktop/workspace/os/performance-analyzer/build/test-results/integTest
Generating HTML test report...
Finished generating test html results (0.028 secs) into: /Users/partsrut/Desktop/workspace/os/performance-analyzer/build/reports/tests/integTest
Stored cache entry for task ':integTest' with cache key 93b0fd5ad6e3b1fe1dfa141d2c6eacb7
Stopping `node{::integTest-0}`, tailLogs: false
Terminating opensearch process forcibly : commandLine:`/Library/Java/JavaVirtualMachines/jdk-14.0.1.jdk/Contents/Home/bin/java -Xshare:auto -Dopensearch.networkaddress.cache.ttl=60 -Dopensearch.networkaddress.cache.negative.ttl=10 -XX:+AlwaysPreTouch -Xss1m -Djava.awt.headless=true -Dfile.encoding=UTF-8 -Djna.nosys=true -XX:-OmitStackTraceInFastThrow -XX:+ShowCodeDetailsInExceptionMessages -Dio.netty.noUnsafe=true -Dio.netty.noKeySetOptimization=true -Dio.netty.recycler.maxCapacityPerThread=0 -Dio.netty.allocator.numDirectArenas=0 -Dlog4j.shutdownHookEnabled=false -Dlog4j2.disable.jmx=true -Djava.locale.providers=SPI,COMPAT -Xms1g -Xmx1g -XX:+UseG1GC -XX:G1ReservePercent=25 -XX:InitiatingHeapOccupancyPercent=30 -Djava.io.tmpdir=/Users/partsrut/Desktop/workspace/os/performance-analyzer/build/testclusters/integTest-0/tmp -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=logs -XX:ErrorFile=logs/hs_err_pid%p.log -Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m -Xms512m -Xmx512m -ea -esa -XX:MaxDirectMemorySize=268435456 -Dopensearch.path.home=/Users/partsrut/.gradle/caches/transforms-2/files-2.1/4a88693c14b18a257728120403a43df6/opensearch-1.0.0.zip/opensearch-1.0.0 -Dopensearch.path.conf=/Users/partsrut/Desktop/workspace/os/performance-analyzer/build/testclusters/integTest-0/config -Dopensearch.distribution.type=zip -Dopensearch.bundled_jdk=false -cp /Users/partsrut/.gradle/caches/transforms-2/files-2.1/4a88693c14b18a257728120403a43df6/opensearch-1.0.0.zip/opensearch-1.0.0/lib/* org.opensearch.bootstrap.OpenSearch` command:`/Library/Java/JavaVirtualMachines/jdk-14.0.1.jdk/Contents/Home/bin/java` args:`'-Xshare:auto' '-Dopensearch.networkaddress.cache.ttl=60' '-Dopensearch.networkaddress.cache.negative.ttl=10' '-XX:+AlwaysPreTouch' '-Xss1m' '-Djava.awt.headless=true' '-Dfile.encoding=UTF-8' '-Djna.nosys=true' '-XX:-OmitStackTraceInFastThrow' '-XX:+ShowCodeDetailsInExceptionMessages' '-Dio.netty.noUnsafe=true' '-Dio.netty.noKeySetOptimization=true' '-Dio.netty.recycler.maxCapacityPerThread=0' '-Dio.netty.allocator.numDirectArenas=0' '-Dlog4j.shutdownHookEnabled=false' '-Dlog4j2.disable.jmx=true' '-Djava.locale.providers=SPI,COMPAT' '-Xms1g' '-Xmx1g' '-XX:+UseG1GC' '-XX:G1ReservePercent=25' '-XX:InitiatingHeapOccupancyPercent=30' '-Djava.io.tmpdir=/Users/partsrut/Desktop/workspace/os/performance-analyzer/build/testclusters/integTest-0/tmp' '-XX:+HeapDumpOnOutOfMemoryError' '-XX:HeapDumpPath=logs' '-XX:ErrorFile=logs/hs_err_pid%p.log' '-Xlog:gc*,gc+age=trace,safepoint:file=logs/gc.log:utctime,pid,tags:filecount=32,filesize=64m' '-Xms512m' '-Xmx512m' '-ea' '-esa' '-XX:MaxDirectMemorySize=268435456' '-Dopensearch.path.home=/Users/partsrut/.gradle/caches/transforms-2/files-2.1/4a88693c14b18a257728120403a43df6/opensearch-1.0.0.zip/opensearch-1.0.0' '-Dopensearch.path.conf=/Users/partsrut/Desktop/workspace/os/performance-analyzer/build/testclusters/integTest-0/config' '-Dopensearch.distribution.type=zip' '-Dopensearch.bundled_jdk=false' '-cp' '/Users/partsrut/.gradle/caches/transforms-2/files-2.1/4a88693c14b18a257728120403a43df6/opensearch-1.0.0.zip/opensearch-1.0.0/lib/*' 'org.opensearch.bootstrap.OpenSearch'`
:integTest (Thread[Execution worker for ':' Thread 2,5,main]) completed. Took 22.935 secs.
Waiting for reaper to exit normally

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.6.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 3m 5s
```

### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
