### PR TITLE
Handling empty flow unit during Cache/Queue RCA execution

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/rca/framework/metrics/RcaGraphMetrics.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/framework/metrics/RcaGraphMetrics.java
@@ -80,6 +80,12 @@ public enum RcaGraphMetrics implements MeasurementSet {
     /** Measures number of bytes that was received as part of a protobuf message. */
     NET_BYTES_IN("TotalRcaBytesInSerialized", "bytes", Collections.singletonList(Statistics.SUM)),
 
+    /** RCA Node received an empty Flow Unit */
+    RCA_RX_EMPTY_FU(
+            "RcaReceivedEmptyFU",
+            "namedCount",
+            Collections.singletonList(Statistics.NAMED_COUNTERS)),
+
     /** Number of nodes that are currently publishing flow units to downstream nodes. */
     RCA_NODES_FU_PUBLISH_COUNT(
             "RcaFlowUnitPublishCount",

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/cache/FieldDataCacheRca.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/cache/FieldDataCacheRca.java
@@ -224,7 +224,7 @@ public class FieldDataCacheRca extends Rca<ResourceFlowUnit<HotNodeSummary>> {
                         // If the RCA receives 3 empty flow units, re-set the 'hasMetric' value
                         hasEvictions = false;
                         clearCounter = 0;
-                        LOG.error(
+                        LOG.debug(
                                 "{} encountered {} empty flow units, re-setting the 'hasEvictions value'.",
                                 this.getClass().getSimpleName(),
                                 consecutivePeriodsToClear);

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/cache/FieldDataCacheRca.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/cache/FieldDataCacheRca.java
@@ -51,6 +51,7 @@ import org.opensearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSum
 import org.opensearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
 import org.opensearch.performanceanalyzer.rca.framework.api.summaries.ResourceUtil;
 import org.opensearch.performanceanalyzer.rca.framework.core.RcaConf;
+import org.opensearch.performanceanalyzer.rca.framework.metrics.RcaGraphMetrics;
 import org.opensearch.performanceanalyzer.rca.framework.metrics.RcaVerticesMetrics;
 import org.opensearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import org.opensearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
@@ -195,6 +196,8 @@ public class FieldDataCacheRca extends Rca<ResourceFlowUnit<HotNodeSummary>> {
         private boolean hasEvictions;
         private long evictionTimestamp;
         private long metricTimePeriodInMillis;
+        private int clearCounter;
+        private int consecutivePeriodsToClear;
 
         private CacheEvictionCollector(
                 final Resource cache,
@@ -205,6 +208,8 @@ public class FieldDataCacheRca extends Rca<ResourceFlowUnit<HotNodeSummary>> {
             this.hasEvictions = false;
             this.evictionTimestamp = 0;
             this.metricTimePeriodInMillis = TimeUnit.SECONDS.toMillis(metricTimePeriodInMillis);
+            this.clearCounter = 0;
+            this.consecutivePeriodsToClear = 3;
         }
 
         public void setCollectorTimePeriod(long metricTimePeriodInMillis) {
@@ -214,6 +219,18 @@ public class FieldDataCacheRca extends Rca<ResourceFlowUnit<HotNodeSummary>> {
         public void collect(final long currTimestamp) {
             for (MetricFlowUnit flowUnit : cacheEvictionMetrics.getFlowUnits()) {
                 if (flowUnit.isEmpty() || flowUnit.getData() == null) {
+                    clearCounter += 1;
+                    if (clearCounter > consecutivePeriodsToClear) {
+                        // If the RCA receives 3 empty flow units, re-set the 'hasMetric' value
+                        hasEvictions = false;
+                        clearCounter = 0;
+                        LOG.error(
+                                "{} encountered {} empty flow units, re-setting the 'hasEvictions value'.",
+                                this.getClass().getSimpleName(),
+                                consecutivePeriodsToClear);
+                    }
+                    PerformanceAnalyzerApp.RCA_GRAPH_METRICS_AGGREGATOR.updateStat(
+                            RcaGraphMetrics.RCA_RX_EMPTY_FU, this.getClass().getSimpleName(), 1);
                     continue;
                 }
 

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/cache/ShardRequestCacheRca.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/cache/ShardRequestCacheRca.java
@@ -247,7 +247,7 @@ public class ShardRequestCacheRca extends Rca<ResourceFlowUnit<HotNodeSummary>> 
                         // If the RCA receives 3 empty flow units, re-set the 'hasCacheMetric' value
                         hasCacheMetric = false;
                         clearCounter = 0;
-                        LOG.error(
+                        LOG.debug(
                                 "{} encountered {} empty flow units, re-setting the hasCacheMetric value.",
                                 this.getClass().getSimpleName(),
                                 consecutivePeriodsToClear);

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/cache/ShardRequestCacheRca.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/cache/ShardRequestCacheRca.java
@@ -53,6 +53,7 @@ import org.opensearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSum
 import org.opensearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
 import org.opensearch.performanceanalyzer.rca.framework.api.summaries.ResourceUtil;
 import org.opensearch.performanceanalyzer.rca.framework.core.RcaConf;
+import org.opensearch.performanceanalyzer.rca.framework.metrics.RcaGraphMetrics;
 import org.opensearch.performanceanalyzer.rca.framework.metrics.RcaVerticesMetrics;
 import org.opensearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import org.opensearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
@@ -217,17 +218,21 @@ public class ShardRequestCacheRca extends Rca<ResourceFlowUnit<HotNodeSummary>> 
     private static class CacheCollector {
         private final Resource cache;
         private final Metric cacheMetrics;
-        private boolean hasMetric;
+        private boolean hasCacheMetric;
         private long metricTimestamp;
         private long metricTimePeriodInMillis;
+        private int clearCounter;
+        private int consecutivePeriodsToClear;
 
         public CacheCollector(
                 final Resource cache, final Metric cacheMetrics, final int metricTimePeriodInSec) {
             this.cache = cache;
             this.cacheMetrics = cacheMetrics;
-            this.hasMetric = false;
+            this.hasCacheMetric = false;
             this.metricTimestamp = 0;
             this.metricTimePeriodInMillis = TimeUnit.SECONDS.toMillis(metricTimePeriodInSec);
+            this.clearCounter = 0;
+            this.consecutivePeriodsToClear = 3;
         }
 
         public void setCollectorTimePeriod(long metricTimePeriodInMillis) {
@@ -237,6 +242,18 @@ public class ShardRequestCacheRca extends Rca<ResourceFlowUnit<HotNodeSummary>> 
         public void collect(final long currTimestamp) {
             for (MetricFlowUnit flowUnit : cacheMetrics.getFlowUnits()) {
                 if (flowUnit.isEmpty()) {
+                    clearCounter += 1;
+                    if (clearCounter > consecutivePeriodsToClear) {
+                        // If the RCA receives 3 empty flow units, re-set the 'hasCacheMetric' value
+                        hasCacheMetric = false;
+                        clearCounter = 0;
+                        LOG.error(
+                                "{} encountered {} empty flow units, re-setting the hasCacheMetric value.",
+                                this.getClass().getSimpleName(),
+                                consecutivePeriodsToClear);
+                    }
+                    PerformanceAnalyzerApp.RCA_GRAPH_METRICS_AGGREGATOR.updateStat(
+                            RcaGraphMetrics.RCA_RX_EMPTY_FU, this.getClass().getSimpleName(), 1);
                     continue;
                 }
 
@@ -247,12 +264,12 @@ public class ShardRequestCacheRca extends Rca<ResourceFlowUnit<HotNodeSummary>> 
                                 .sum();
                 if (!Double.isNaN(metricCount)) {
                     if (metricCount > 0) {
-                        if (!hasMetric) {
+                        if (!hasCacheMetric) {
                             metricTimestamp = currTimestamp;
                         }
-                        hasMetric = true;
+                        hasCacheMetric = true;
                     } else {
-                        hasMetric = false;
+                        hasCacheMetric = false;
                     }
                 } else {
                     LOG.error("Failed to parse metric from cache {}", cache.toString());
@@ -261,7 +278,7 @@ public class ShardRequestCacheRca extends Rca<ResourceFlowUnit<HotNodeSummary>> 
         }
 
         public boolean isUnhealthy(final long currTimestamp) {
-            return hasMetric && (currTimestamp - metricTimestamp) >= metricTimePeriodInMillis;
+            return hasCacheMetric && (currTimestamp - metricTimestamp) >= metricTimePeriodInMillis;
         }
 
         private HotResourceSummary generateSummary(final long currTimestamp) {

--- a/src/test/java/org/opensearch/performanceanalyzer/rca/framework/api/metrics/MetricTestHelper.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/rca/framework/api/metrics/MetricTestHelper.java
@@ -53,6 +53,10 @@ public class MetricTestHelper extends Metric {
         context = DSL.using(new MockConnection(Mock.of(0)));
     }
 
+    public void createEmptyTestFlowUnits() {
+        this.flowUnits = Collections.singletonList(MetricFlowUnit.generic());
+    }
+
     public void createTestFlowUnits(final List<String> fieldNames, final List<String> row) {
         Result<Record> newRecordList = createTestResult(fieldNames, row);
         this.flowUnits = Collections.singletonList(new MetricFlowUnit(0, newRecordList));


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue https://github.com/opensearch-project/performance-analyzer-rca/issues/33

[RCA] Handle Empty FU within Cache and Queue RCAs

In this case, PA was unable to persist value for 64 metric for the one hour window and thus, RCA was running into Cache_Request_Hit metric table does not exist. Returning null for the metric/dimension and QueryMetric was returning empty Flow units to ShardRequestCacheRCA. The ShardRequestCacheRCA on finding an empty FU, [ignores it](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/cache/ShardRequestCacheRca.java#L240). This was done to accommodate any delays in metric persistence from PA. 

Before this event, the ShardReqestCacheRCA had [hasMetric](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/cache/ShardRequestCacheRca.java#L253) set to true and this variable was not reset during the 1 hour (RCA was ignoring the empty flow units). Thus, the RCA was in Unhealthy state and CacheDecider was repeatedly suggesting ‘ModifyCacheMaxSize’. 

This same code is shared across [Queue RCA](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/threadpool/QueueRejectionRca.java#L187) and [FieldDataCacheRca](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/cache/FieldDataCacheRca.java, so we will need to fix this there as well


**Describe the solution you are proposing**
A clear and concise description of what you want to happen.

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
