### PR TITLE
Adding metric emission + UT for RCA_FRAMEWORK_CRASH

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/rca/RcaController.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/RcaController.java
@@ -63,6 +63,7 @@ import org.opensearch.performanceanalyzer.rca.framework.core.Queryable;
 import org.opensearch.performanceanalyzer.rca.framework.core.RcaConf;
 import org.opensearch.performanceanalyzer.rca.framework.core.Stats;
 import org.opensearch.performanceanalyzer.rca.framework.core.ThresholdMain;
+import org.opensearch.performanceanalyzer.rca.framework.metrics.ExceptionsAndErrors;
 import org.opensearch.performanceanalyzer.rca.framework.metrics.RcaRuntimeMetrics;
 import org.opensearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import org.opensearch.performanceanalyzer.rca.framework.util.RcaConsts;
@@ -338,6 +339,8 @@ public class RcaController {
                     Thread.sleep(rcaStateCheckIntervalMillis - duration);
                 }
             } catch (InterruptedException ie) {
+                PerformanceAnalyzerApp.ERRORS_AND_EXCEPTIONS_AGGREGATOR.updateStat(
+                        ExceptionsAndErrors.RCA_FRAMEWORK_CRASH, "", 1);
                 if (deliberateInterrupt) {
                     // This should only happen in case of tests. So, its okay for this log level to
                     // be info.

--- a/src/test/java/org/opensearch/performanceanalyzer/rca/RcaControllerTest.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/rca/RcaControllerTest.java
@@ -63,6 +63,7 @@ import org.opensearch.performanceanalyzer.net.GRPCConnectionManager;
 import org.opensearch.performanceanalyzer.rca.framework.core.ConnectedComponent;
 import org.opensearch.performanceanalyzer.rca.framework.core.RcaConf;
 import org.opensearch.performanceanalyzer.rca.framework.core.Stats;
+import org.opensearch.performanceanalyzer.rca.framework.metrics.ExceptionsAndErrors;
 import org.opensearch.performanceanalyzer.rca.framework.util.RcaConsts;
 import org.opensearch.performanceanalyzer.rca.scheduler.RCAScheduler;
 import org.opensearch.performanceanalyzer.rca.scheduler.RcaSchedulerState;
@@ -201,6 +202,12 @@ public class RcaControllerTest {
         } catch (InterruptedException ie) {
             ie.printStackTrace();
         }
+    }
+
+    @Test
+    public void rcaFrameworkCrash() throws InterruptedException {
+        controllerThread.interrupt();
+        Assert.assertTrue(RcaTestHelper.verify(ExceptionsAndErrors.RCA_FRAMEWORK_CRASH));
     }
 
     @Test

--- a/src/test/java/org/opensearch/performanceanalyzer/rca/RcaTestHelper.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/rca/RcaTestHelper.java
@@ -50,9 +50,11 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.FileAppender;
 import org.jooq.tools.json.JSONObject;
 import org.opensearch.performanceanalyzer.AppContext;
+import org.opensearch.performanceanalyzer.PerformanceAnalyzerApp;
 import org.opensearch.performanceanalyzer.metrics.AllMetrics;
 import org.opensearch.performanceanalyzer.rca.framework.core.ConnectedComponent;
 import org.opensearch.performanceanalyzer.rca.framework.core.Node;
+import org.opensearch.performanceanalyzer.rca.stats.measurements.MeasurementSet;
 import org.opensearch.performanceanalyzer.reader.ClusterDetailsEventProcessor;
 import org.opensearch.performanceanalyzer.reader_writer_shared.Event;
 
@@ -198,5 +200,17 @@ public class RcaTestHelper {
         ArrayNode array = mapper.valueToTree(mutedComponents);
         ((ObjectNode) configObject).putArray(componentKey).addAll(array);
         mapper.writeValue(new FileOutputStream(rcaConfPath), configObject);
+    }
+
+    public static boolean verify(MeasurementSet measurementSet) throws InterruptedException {
+        final int MAX_TIME_TO_WAIT_MILLIS = 10_000;
+        int waited_for_millis = 0;
+        while (waited_for_millis++ < MAX_TIME_TO_WAIT_MILLIS) {
+            if (PerformanceAnalyzerApp.RCA_STATS_REPORTER.isMeasurementCollected(measurementSet)) {
+                return true;
+            }
+            Thread.sleep(1);
+        }
+        return false;
     }
 }

--- a/src/test/java/org/opensearch/performanceanalyzer/rca/listener/MisbehavingGraphOperateMethodListenerTest.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/rca/listener/MisbehavingGraphOperateMethodListenerTest.java
@@ -36,7 +36,6 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import org.opensearch.performanceanalyzer.AppContext;
-import org.opensearch.performanceanalyzer.PerformanceAnalyzerApp;
 import org.opensearch.performanceanalyzer.collectors.StatsCollector;
 import org.opensearch.performanceanalyzer.rca.RcaTestHelper;
 import org.opensearch.performanceanalyzer.rca.framework.api.AnalysisGraph;
@@ -55,7 +54,6 @@ import org.opensearch.performanceanalyzer.rca.framework.util.RcaConsts;
 import org.opensearch.performanceanalyzer.rca.framework.util.RcaUtil;
 import org.opensearch.performanceanalyzer.rca.scheduler.RCASchedulerTask;
 import org.opensearch.performanceanalyzer.rca.spec.MetricsDBProviderTestHelper;
-import org.opensearch.performanceanalyzer.rca.stats.measurements.MeasurementSet;
 
 public class MisbehavingGraphOperateMethodListenerTest {
     class FaultyAnalysisGraph extends AnalysisGraph {
@@ -121,25 +119,13 @@ public class MisbehavingGraphOperateMethodListenerTest {
 
         for (int i = 0; i <= MisbehavingGraphOperateMethodListener.TOLERANCE_LIMIT; i++) {
             rcaSchedulerTask.run();
-            Assert.assertTrue(verify(ExceptionsAndErrors.EXCEPTION_IN_OPERATE));
+            Assert.assertTrue(RcaTestHelper.verify(ExceptionsAndErrors.EXCEPTION_IN_OPERATE));
         }
 
         Assert.assertEquals(1, Stats.getInstance().getMutedGraphNodesCount());
         Assert.assertTrue(
                 Stats.getInstance()
                         .isNodeMuted(FaultyAnalysisGraph.HighCpuSymptom.class.getSimpleName()));
-    }
-
-    private boolean verify(MeasurementSet measurementSet) throws InterruptedException {
-        final int MAX_TIME_TO_WAIT_MILLIS = 10_000;
-        int waited_for_millis = 0;
-        while (waited_for_millis++ < MAX_TIME_TO_WAIT_MILLIS) {
-            if (PerformanceAnalyzerApp.RCA_STATS_REPORTER.isMeasurementCollected(measurementSet)) {
-                return true;
-            }
-            Thread.sleep(1);
-        }
-        return false;
     }
 
     @After


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
`RCA_FRAMEWORK_CRASH` metric should be emitted when the top level controller thread crashes

The metric is already present [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/src/main/java/org/opensearch/performanceanalyzer/rca/framework/metrics/ExceptionsAndErrors.java#L36) but we never emit this metric.


**Describe the solution you are proposing**
A clear and concise description of what you want to happen.

**Describe alternatives you've considered**

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
