### PR TITLE
Addressing changes for StatsCollector

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/PerformanceAnalyzerApp.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/PerformanceAnalyzerApp.java
@@ -142,8 +142,6 @@ public class PerformanceAnalyzerApp {
                                     / 2,
                             TimeUnit.MILLISECONDS);
             METRIC_COLLECTOR_EXECUTOR.addScheduledMetricCollector(StatsCollector.instance());
-            StatsCollector.instance()
-                    .addDefaultExceptionCode(StatExceptionCode.READER_RESTART_PROCESSING);
             METRIC_COLLECTOR_EXECUTOR.setEnabled(true);
             METRIC_COLLECTOR_EXECUTOR.start();
 
@@ -158,7 +156,6 @@ public class PerformanceAnalyzerApp {
             startRcaTopLevelThread(clientServers, connectionManager, appContext, THREAD_PROVIDER);
         } else {
             LOG.error("Performance analyzer app stopped due to invalid config status.");
-            StatsCollector.instance().logException(StatExceptionCode.READER_THREAD_STOPPED);
         }
     }
 
@@ -235,12 +232,12 @@ public class PerformanceAnalyzerApp {
         // As an improvement to this functionality, once we know what exceptions are retryable, we
         // can have each thread also register an error handler for itself. This handler will know
         // what to do when the thread has stopped due to an unexpected exception.
+        READER_METRICS_AGGREGATOR.updateStat(ReaderMetrics.OTHER, "", 1);
         LOG.error(
                 "Thread: {} ran into an uncaught exception: {}",
                 exception.getPaThreadName(),
                 exception.getInnerThrowable(),
                 exception);
-        StatsCollector.instance().logException(exception.getExceptionCode());
     }
 
     public static Thread startWebServerThread(

--- a/src/main/java/org/opensearch/performanceanalyzer/PerformanceAnalyzerThreads.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/PerformanceAnalyzerThreads.java
@@ -27,7 +27,8 @@
 package org.opensearch.performanceanalyzer;
 
 
-import org.opensearch.performanceanalyzer.collectors.StatExceptionCode;
+import org.opensearch.performanceanalyzer.rca.framework.metrics.ReaderMetrics;
+import org.opensearch.performanceanalyzer.rca.stats.measurements.MeasurementSet;
 
 /**
  * Enum of threads that are spawned by Performance Analyzer agent. Each enum value encapsulates two
@@ -35,17 +36,17 @@ import org.opensearch.performanceanalyzer.collectors.StatExceptionCode;
  * need to be recorded when the thread runs into an unhandled exception.
  */
 public enum PerformanceAnalyzerThreads {
-    PA_READER("pa-reader", StatExceptionCode.READER_THREAD_STOPPED),
-    PA_ERROR_HANDLER("pa-error-handler", StatExceptionCode.ERROR_HANDLER_THREAD_STOPPED),
-    GRPC_SERVER("grpc-server", StatExceptionCode.GRPC_SERVER_THREAD_STOPPED),
-    WEB_SERVER("web-server", StatExceptionCode.WEB_SERVER_THREAD_STOPPED),
-    RCA_CONTROLLER("rca-controller", StatExceptionCode.RCA_CONTROLLER_THREAD_STOPPED),
-    RCA_SCHEDULER("rca-scheduler", StatExceptionCode.RCA_SCHEDULER_THREAD_STOPPED);
+    PA_READER("pa-reader", ReaderMetrics.READER_THREAD_STOPPED),
+    PA_ERROR_HANDLER("pa-error-handler", ReaderMetrics.ERROR_HANDLER_THREAD_STOPPED),
+    GRPC_SERVER("grpc-server", ReaderMetrics.GRPC_SERVER_THREAD_STOPPED),
+    WEB_SERVER("web-server", ReaderMetrics.WEB_SERVER_THREAD_STOPPED),
+    RCA_CONTROLLER("rca-controller", ReaderMetrics.RCA_CONTROLLER_THREAD_STOPPED),
+    RCA_SCHEDULER("rca-scheduler", ReaderMetrics.RCA_SCHEDULER_THREAD_STOPPED);
 
     private final String value;
-    private final StatExceptionCode threadExceptionCode;
+    private final MeasurementSet threadExceptionCode;
 
-    PerformanceAnalyzerThreads(final String value, final StatExceptionCode threadExceptionCode) {
+    PerformanceAnalyzerThreads(final String value, final MeasurementSet threadExceptionCode) {
         this.value = value;
         this.threadExceptionCode = threadExceptionCode;
     }
@@ -67,7 +68,7 @@ public enum PerformanceAnalyzerThreads {
      *
      * @return the name of the counter.
      */
-    public StatExceptionCode getThreadExceptionCode() {
+    public MeasurementSet getThreadExceptionCode() {
         return threadExceptionCode;
     }
 }

--- a/src/main/java/org/opensearch/performanceanalyzer/collectors/ScheduledMetricCollectorsExecutor.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/collectors/ScheduledMetricCollectorsExecutor.java
@@ -123,7 +123,9 @@ public class ScheduledMetricCollectorsExecutor extends Thread {
                         if (collector.getState()
                                 == PerformanceAnalyzerMetricsCollector.State.MUTED) {
                             PerformanceAnalyzerApp.WRITER_METRICS_AGGREGATOR.updateStat(
-                                    WriterMetrics.COLLECTORS_MUTED, "", 1);
+                                    WriterMetrics.COLLECTORS_MUTED,
+                                    collector.getCollectorName(),
+                                    1);
                             continue;
                         }
                         metricsCollectors.put(

--- a/src/main/java/org/opensearch/performanceanalyzer/collectors/StatExceptionCode.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/collectors/StatExceptionCode.java
@@ -62,21 +62,11 @@ public enum StatExceptionCode {
     RCA_VERTEX_RX_BUFFER_FULL_ERROR("RcaVertexRxBufferFullError"),
     RCA_NETWORK_THREADPOOL_QUEUE_FULL_ERROR("RcaNetworkThreadpoolQueueFullError"),
     RCA_SCHEDULER_STOPPED_ERROR("RcaSchedulerStoppedError"),
-    READER_THREAD_STOPPED("ReaderThreadStopped"),
-    ERROR_HANDLER_THREAD_STOPPED("ErrorHandlerThreadStopped"),
-    GRPC_SERVER_THREAD_STOPPED("GRPCServerThreadStopped"),
-    WEB_SERVER_THREAD_STOPPED("WebServerThreadStopped"),
-    RCA_CONTROLLER_THREAD_STOPPED("RcaControllerThreadStopped"),
-    RCA_SCHEDULER_THREAD_STOPPED("RcaSchedulerThreadStopped"),
-    JVM_THREAD_ID_NO_LONGER_EXISTS("JVMThreadIdNoLongerExists"),
     OPENSEARCH_REQUEST_INTERCEPTOR_ERROR("OpenSearchRequestInterceptorError"),
-    INVALID_OLD_GEN_SIZE("InvalidOldGenSize"),
     MISCONFIGURED_OLD_GEN_RCA_HEAP_MAX_MISSING("MisconfiguredOldGenRcaHeapMaxMissing"),
     MISCONFIGURED_OLD_GEN_RCA_HEAP_USED_MISSING("MisconfiguredOldGenRcaHeapUsedMissing"),
     MISCONFIGURED_OLD_GEN_RCA_GC_EVENTS_MISSING("MisconfiguredOldGenRcaGcEventsMissing"),
-    TOTAL_MEM_READ_ERROR("TotalMemReadError"),
-    CONFIG_DIR_NOT_FOUND("ConfigDirectoryNotFound"),
-    OTHER("Other");
+    TOTAL_MEM_READ_ERROR("TotalMemReadError");
 
     private final String value;
 

--- a/src/main/java/org/opensearch/performanceanalyzer/collectors/StatsCollector.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/collectors/StatsCollector.java
@@ -102,9 +102,6 @@ public class StatsCollector extends PerformanceAnalyzerMetricsCollector {
         Map<String, AtomicInteger> currentCounters = counters;
         counters = new ConcurrentHashMap<>();
 
-        // currentCounters.putIfAbsent(StatExceptionCode.TOTAL_ERROR.toString(), new
-        // AtomicInteger(0));
-
         for (StatExceptionCode statExceptionCode : defaultExceptionCodes) {
             currentCounters.putIfAbsent(statExceptionCode.toString(), new AtomicInteger(0));
         }

--- a/src/main/java/org/opensearch/performanceanalyzer/decisionmaker/deciders/jvm/sizing/HeapSizeIncreasePolicy.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/decisionmaker/deciders/jvm/sizing/HeapSizeIncreasePolicy.java
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
 import org.opensearch.performanceanalyzer.AppContext;
-import org.opensearch.performanceanalyzer.collectors.StatsCollector;
+import org.opensearch.performanceanalyzer.PerformanceAnalyzerApp;
 import org.opensearch.performanceanalyzer.decisionmaker.actions.Action;
 import org.opensearch.performanceanalyzer.decisionmaker.actions.HeapSizeIncreaseAction;
 import org.opensearch.performanceanalyzer.decisionmaker.deciders.AlarmMonitor;
@@ -46,13 +46,13 @@ import org.opensearch.performanceanalyzer.rca.framework.api.flow_units.ResourceF
 import org.opensearch.performanceanalyzer.rca.framework.api.summaries.HotClusterSummary;
 import org.opensearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
 import org.opensearch.performanceanalyzer.rca.framework.core.RcaConf;
+import org.opensearch.performanceanalyzer.rca.framework.metrics.RcaRuntimeMetrics;
 import org.opensearch.performanceanalyzer.rca.framework.util.RcaConsts;
 import org.opensearch.performanceanalyzer.rca.store.rca.cluster.NodeKey;
 import org.opensearch.performanceanalyzer.rca.store.rca.jvmsizing.LargeHeapClusterRca;
 
 public class HeapSizeIncreasePolicy implements DecisionPolicy {
 
-    private static final String HEAP_SIZE_INCREASE_ACTION_RECOMMENDED = "RecommendHeapSizeIncrease";
     private final LargeHeapClusterRca largeHeapClusterRca;
     private AppContext appContext;
     private RcaConf rcaConf;
@@ -73,7 +73,8 @@ public class HeapSizeIncreasePolicy implements DecisionPolicy {
         if (!heapSizeIncreaseClusterMonitor.isHealthy()) {
             Action heapSizeIncreaseAction = new HeapSizeIncreaseAction(appContext);
             if (heapSizeIncreaseAction.isActionable()) {
-                StatsCollector.instance().logMetric(HEAP_SIZE_INCREASE_ACTION_RECOMMENDED);
+                PerformanceAnalyzerApp.RCA_RUNTIME_METRICS_AGGREGATOR.updateStat(
+                        RcaRuntimeMetrics.HEAP_SIZE_INCREASE_ACTION_SUGGESTED, "", 1);
                 actions.add(heapSizeIncreaseAction);
             }
         }

--- a/src/main/java/org/opensearch/performanceanalyzer/jvm/ThreadList.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/jvm/ThreadList.java
@@ -46,11 +46,11 @@ import java.util.regex.Pattern;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.performanceanalyzer.OSMetricsGeneratorFactory;
+import org.opensearch.performanceanalyzer.PerformanceAnalyzerApp;
 import org.opensearch.performanceanalyzer.collectors.ScheduledMetricCollectorsExecutor;
-import org.opensearch.performanceanalyzer.collectors.StatExceptionCode;
-import org.opensearch.performanceanalyzer.collectors.StatsCollector;
 import org.opensearch.performanceanalyzer.core.Util;
 import org.opensearch.performanceanalyzer.metrics.MetricsConfiguration;
+import org.opensearch.performanceanalyzer.rca.framework.metrics.WriterMetrics;
 import sun.tools.attach.HotSpotVirtualMachine;
 
 /** Traverses and prints the stack traces for all Java threads in the remote VM */
@@ -141,8 +141,8 @@ public class ThreadList {
                 vmAttachLock.unlock();
             }
         } else {
-            StatsCollector.instance()
-                    .logException(StatExceptionCode.JVM_ATTACH_LOCK_ACQUISITION_FAILED);
+            PerformanceAnalyzerApp.WRITER_METRICS_AGGREGATOR.updateStat(
+                    WriterMetrics.JVM_ATTACH_LOCK_ACQUISITION_FAILED, "", 1);
         }
 
         // - sending a copy so that if runThreadDump next iteration clears it; caller still has the
@@ -167,7 +167,8 @@ public class ThreadList {
     public static ThreadState getThreadState(long threadId) {
         ThreadState retVal = jTidMap.get(threadId);
         if (retVal == null) {
-            StatsCollector.instance().logException(StatExceptionCode.NO_THREAD_STATE_INFO);
+            PerformanceAnalyzerApp.WRITER_METRICS_AGGREGATOR.updateStat(
+                    WriterMetrics.NO_THREAD_STATE_INFO, "", 1);
         }
         return retVal;
     }
@@ -179,10 +180,11 @@ public class ThreadList {
             vm = VirtualMachine.attach(pid);
         } catch (Exception ex) {
             if (ex.getMessage().contains("java_pid")) {
-                StatsCollector.instance()
-                        .logException(StatExceptionCode.JVM_ATTACH_ERROR_JAVA_PID_FILE_MISSING);
+                PerformanceAnalyzerApp.WRITER_METRICS_AGGREGATOR.updateStat(
+                        WriterMetrics.JVM_ATTACH_ERROR_JAVA_PID_FILE_MISSING, "", 1);
             } else {
-                StatsCollector.instance().logException(StatExceptionCode.JVM_ATTACH_ERROR);
+                PerformanceAnalyzerApp.WRITER_METRICS_AGGREGATOR.updateStat(
+                        WriterMetrics.JVM_ATTACH_ERROR, "", 1);
             }
             // If the thread dump failed then we clean up the old map. So, next time when the
             // collection
@@ -194,16 +196,18 @@ public class ThreadList {
         try (InputStream in = ((HotSpotVirtualMachine) vm).remoteDataDump(args); ) {
             createMap(in);
         } catch (Exception ex) {
-            StatsCollector.instance().logException(StatExceptionCode.JVM_ATTACH_ERROR);
+            PerformanceAnalyzerApp.WRITER_METRICS_AGGREGATOR.updateStat(
+                    WriterMetrics.JVM_ATTACH_ERROR, "", 1);
             oldNativeTidMap.clear();
         }
 
         try {
             vm.detach();
-            StatsCollector.instance()
-                    .logMetric(StatExceptionCode.JVM_THREAD_DUMP_SUCCESSFUL.toString());
+            PerformanceAnalyzerApp.WRITER_METRICS_AGGREGATOR.updateStat(
+                    WriterMetrics.JVM_THREAD_DUMP_SUCCESSFUL, "", 1);
         } catch (Exception ex) {
-            StatsCollector.instance().logException(StatExceptionCode.JVM_ATTACH_ERROR);
+            PerformanceAnalyzerApp.WRITER_METRICS_AGGREGATOR.updateStat(
+                    WriterMetrics.JVM_ATTACH_ERROR, "", 1);
         }
     }
 
@@ -215,8 +219,8 @@ public class ThreadList {
                 // If the ids provided to the getThreadInfo() call are not valid ids or the threads
                 // no
                 // longer exists, then the corresponding info object will contain null.
-                StatsCollector.instance()
-                        .logException(StatExceptionCode.JVM_THREAD_ID_NO_LONGER_EXISTS);
+                PerformanceAnalyzerApp.WRITER_METRICS_AGGREGATOR.updateStat(
+                        WriterMetrics.JVM_THREAD_ID_NO_LONGER_EXISTS, "", 1);
             }
         }
     }

--- a/src/main/java/org/opensearch/performanceanalyzer/metrics/PerformanceAnalyzerMetrics.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/metrics/PerformanceAnalyzerMetrics.java
@@ -196,7 +196,8 @@ public class PerformanceAnalyzerMetrics {
         }
         try {
             if (!keyPathFile.delete()) {
-                // TODO: Add a metric so that we can alarm on file deletion failures.
+                PerformanceAnalyzerApp.WRITER_METRICS_AGGREGATOR.updateStat(
+                        WriterMetrics.METRICS_REMOVE_ERROR, "", 1);
                 LOG.debug("Purge Could not delete file {}", keyPathFile);
             }
         } catch (Exception ex) {

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/RcaController.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/RcaController.java
@@ -50,7 +50,6 @@ import org.opensearch.performanceanalyzer.AppContext;
 import org.opensearch.performanceanalyzer.ClientServers;
 import org.opensearch.performanceanalyzer.PerformanceAnalyzerApp;
 import org.opensearch.performanceanalyzer.PerformanceAnalyzerThreads;
-import org.opensearch.performanceanalyzer.collectors.StatsCollector;
 import org.opensearch.performanceanalyzer.config.PluginSettings;
 import org.opensearch.performanceanalyzer.core.Util;
 import org.opensearch.performanceanalyzer.metrics.AllMetrics;
@@ -65,6 +64,7 @@ import org.opensearch.performanceanalyzer.rca.framework.core.Stats;
 import org.opensearch.performanceanalyzer.rca.framework.core.ThresholdMain;
 import org.opensearch.performanceanalyzer.rca.framework.metrics.ExceptionsAndErrors;
 import org.opensearch.performanceanalyzer.rca.framework.metrics.RcaRuntimeMetrics;
+import org.opensearch.performanceanalyzer.rca.framework.metrics.ReaderMetrics;
 import org.opensearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import org.opensearch.performanceanalyzer.rca.framework.util.RcaConsts;
 import org.opensearch.performanceanalyzer.rca.framework.util.RcaUtil;
@@ -304,7 +304,8 @@ public class RcaController {
     private void restart() {
         stop();
         start();
-        StatsCollector.instance().logMetric(RcaConsts.RCA_SCHEDULER_RESTART_METRIC);
+        PerformanceAnalyzerApp.READER_METRICS_AGGREGATOR.updateStat(
+                ReaderMetrics.RCA_SCHEDULER_RESTART, "", 1);
     }
 
     protected RcaConf getRcaConfForMyRole(AllMetrics.NodeRole role) {
@@ -447,8 +448,9 @@ public class RcaController {
                 rcaScheduler.updateAppContextWithMutedActions(actionsForMute);
             }
         } catch (Exception e) {
+            PerformanceAnalyzerApp.ERRORS_AND_EXCEPTIONS_AGGREGATOR.updateStat(
+                    ExceptionsAndErrors.MUTE_ERROR, "", 1);
             LOG.error("Couldn't read/update the muted RCAs", e);
-            StatsCollector.instance().logMetric(RcaConsts.MUTE_ERROR_METRIC);
             return false;
         }
 

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/framework/core/RcaConf.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/framework/core/RcaConf.java
@@ -55,7 +55,6 @@ import java.util.function.Predicate;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.performanceanalyzer.PerformanceAnalyzerApp;
-import org.opensearch.performanceanalyzer.collectors.StatsCollector;
 import org.opensearch.performanceanalyzer.decisionmaker.actions.configs.CacheActionConfig;
 import org.opensearch.performanceanalyzer.decisionmaker.actions.configs.QueueActionConfig;
 import org.opensearch.performanceanalyzer.decisionmaker.deciders.configs.DeciderConfig;
@@ -74,7 +73,7 @@ import org.opensearch.performanceanalyzer.rca.configs.ShardRequestCacheRcaConfig
 import org.opensearch.performanceanalyzer.rca.framework.api.summaries.bucket.BasicBucketCalculator;
 import org.opensearch.performanceanalyzer.rca.framework.api.summaries.bucket.BucketCalculator;
 import org.opensearch.performanceanalyzer.rca.framework.api.summaries.bucket.UsageBucket;
-import org.opensearch.performanceanalyzer.rca.framework.util.RcaConsts;
+import org.opensearch.performanceanalyzer.rca.framework.metrics.ExceptionsAndErrors;
 
 public class RcaConf {
 
@@ -292,8 +291,9 @@ public class RcaConf {
         for (String confFilePath : rcaConfFiles) {
             updateStatus = updateRcaConf(confFilePath, mutedRcas, mutedDeciders, mutedActions);
             if (!updateStatus) {
+                PerformanceAnalyzerApp.ERRORS_AND_EXCEPTIONS_AGGREGATOR.updateStat(
+                        ExceptionsAndErrors.WRITE_UPDATED_RCA_CONF_ERROR, "", 1);
                 LOG.error("Failed to update the conf file at path: {}", confFilePath);
-                StatsCollector.instance().logMetric(RcaConsts.WRITE_UPDATED_RCA_CONF_ERROR);
                 break;
             }
         }

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/framework/metrics/ExceptionsAndErrors.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/framework/metrics/ExceptionsAndErrors.java
@@ -35,6 +35,12 @@ import org.opensearch.performanceanalyzer.rca.stats.measurements.MeasurementSet;
 public enum ExceptionsAndErrors implements MeasurementSet {
     RCA_FRAMEWORK_CRASH("RcaFrameworkCrash"),
 
+    CONFIG_DIR_NOT_FOUND("ConfigDirectoryNotFound"),
+
+    WRITE_UPDATED_RCA_CONF_ERROR("WriteUpdatedRcaConfError"),
+
+    MUTE_ERROR("MuteError"),
+
     /**
      * These are the cases when an exception was throws in the {@code operate()} method, that each
      * RCA graph node implements.
@@ -73,7 +79,9 @@ public enum ExceptionsAndErrors implements MeasurementSet {
 
     ELECTION_TERM_COLLECTOR_ERROR("ElectionTermCollectorError"),
 
-    SHARD_INDEXING_PRESSURE_COLLECTOR_ERROR("ShardIndexingPressureMetricsCollectorError");
+    SHARD_INDEXING_PRESSURE_COLLECTOR_ERROR("ShardIndexingPressureMetricsCollectorError"),
+
+    NODESTATS_COLLECTION_ERROR("NodeStatsCollectionError");
 
     /** What we want to appear as the metric name. */
     private String name;

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/framework/metrics/RcaGraphMetrics.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/framework/metrics/RcaGraphMetrics.java
@@ -57,16 +57,10 @@ public enum RcaGraphMetrics implements MeasurementSet {
             "millis",
             Arrays.asList(Statistics.MAX, Statistics.MEAN, Statistics.SUM)),
 
-    /** Measures the time spent in the persistence layer. */
-    RCA_PERSIST_CALL(
-            "RcaPersistCall",
-            "micros",
-            Arrays.asList(Statistics.MAX, Statistics.MEAN, Statistics.SUM)),
-
     NUM_GRAPH_NODES("NumGraphNodes", "count", Collections.singletonList(Statistics.SAMPLE)),
 
     NUM_GRAPH_NODES_MUTED(
-            "NUMOfMutedGraphNodes", "count", Collections.singletonList(Statistics.SAMPLE)),
+            "NumOfMutedGraphNodes", "count", Collections.singletonList(Statistics.SAMPLE)),
 
     NUM_NODES_EXECUTED_LOCALLY(
             "NodesExecutedLocally", "count", Collections.singletonList(Statistics.COUNT)),
@@ -85,6 +79,16 @@ public enum RcaGraphMetrics implements MeasurementSet {
             "RcaReceivedEmptyFU",
             "namedCount",
             Collections.singletonList(Statistics.NAMED_COUNTERS)),
+
+    /** Number of Network Error encountered per node. */
+    RCA_NETWORK_ERROR(
+            "RcaNetworkError", "namedCount", Collections.singletonList(Statistics.NAMED_COUNTERS)),
+
+    /** Measures the time spent in the persistence layer. */
+    RCA_PERSIST_CALL(
+            "RcaPersistCall",
+            "micros",
+            Arrays.asList(Statistics.MAX, Statistics.MEAN, Statistics.SUM)),
 
     /** Number of nodes that are currently publishing flow units to downstream nodes. */
     RCA_NODES_FU_PUBLISH_COUNT(

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/framework/metrics/RcaRuntimeMetrics.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/framework/metrics/RcaRuntimeMetrics.java
@@ -58,6 +58,10 @@ public enum RcaRuntimeMetrics implements MeasurementSet {
     NO_INCREASE_ACTION_SUGGESTED(
             "NoIncreaseAction", "namedCount", Collections.singletonList(Statistics.NAMED_COUNTERS)),
 
+    /** Metric tracking the Heap Size increase action published by the publisher. */
+    HEAP_SIZE_INCREASE_ACTION_SUGGESTED(
+            "HeapSizeIncreaseAction", "count", Collections.singletonList(Statistics.COUNT)),
+
     /** Metric tracking the actions published by the publisher that are persisted in sqlite. */
     ACTIONS_PUBLISHED(
             "ActionsPublished", "namedCount", Collections.singletonList(Statistics.NAMED_COUNTERS));

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/framework/metrics/RcaVerticesMetrics.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/framework/metrics/RcaVerticesMetrics.java
@@ -36,6 +36,15 @@ import org.opensearch.performanceanalyzer.rca.stats.measurements.MeasurementSet;
  * metrics added by each RCA vertex in RCA graph. All metrics under this category are RCA specific
  */
 public enum RcaVerticesMetrics implements MeasurementSet {
+    INVALID_OLD_GEN_SIZE("InvalidOldGenSize", "count", Collections.singletonList(Statistics.COUNT)),
+    OLD_GEN_RECLAMATION_INEFFECTIVE(
+            "OldGenReclamationIneffective", "count", Collections.singletonList(Statistics.COUNT)),
+    OLD_GEN_CONTENDED("OldGenContended", "count", Collections.singletonList(Statistics.COUNT)),
+    OLD_GEN_OVER_OCCUPIED(
+            "OldGenOverOccupied", "count", Collections.singletonList(Statistics.COUNT)),
+
+    HOT_SHARD_RCA_ERROR("HotShardRcaError", "count", Collections.singletonList(Statistics.COUNT)),
+
     NUM_YOUNG_GEN_RCA_TRIGGERED(
             "YoungGenRcaCount", "count", Collections.singletonList(Statistics.COUNT)),
     NUM_OLD_GEN_RCA_TRIGGERED(
@@ -54,7 +63,6 @@ public enum RcaVerticesMetrics implements MeasurementSet {
             "ClusterRcaNamedCount",
             "namedCount",
             Collections.singletonList(Statistics.NAMED_COUNTERS));
-
     /** What we want to appear as the metric name. */
     private String name;
 

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/framework/metrics/RcaVerticesMetrics.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/framework/metrics/RcaVerticesMetrics.java
@@ -37,9 +37,12 @@ import org.opensearch.performanceanalyzer.rca.stats.measurements.MeasurementSet;
  */
 public enum RcaVerticesMetrics implements MeasurementSet {
     INVALID_OLD_GEN_SIZE("InvalidOldGenSize", "count", Collections.singletonList(Statistics.COUNT)),
+
     OLD_GEN_RECLAMATION_INEFFECTIVE(
             "OldGenReclamationIneffective", "count", Collections.singletonList(Statistics.COUNT)),
+
     OLD_GEN_CONTENDED("OldGenContended", "count", Collections.singletonList(Statistics.COUNT)),
+
     OLD_GEN_OVER_OCCUPIED(
             "OldGenOverOccupied", "count", Collections.singletonList(Statistics.COUNT)),
 

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/framework/metrics/ReaderMetrics.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/framework/metrics/ReaderMetrics.java
@@ -35,6 +35,54 @@ import org.opensearch.performanceanalyzer.rca.stats.measurements.MeasurementSet;
 
 public enum ReaderMetrics implements MeasurementSet {
 
+    /**
+     * We start 6 threads within RCA Agent, details at {@link
+     * org.opensearch.performanceanalyzer.PerformanceAnalyzerThreads}. Below metrics track count of
+     * thread started and ended.
+     */
+    NUM_PA_THREADS_STARTED(
+            "NumberOfPAThreadsStarted", "namedCount", Collections.singletonList(Statistics.COUNT)),
+
+    NUM_PA_THREADS_ENDED(
+            "NumberOfPAThreadsEnded", "namedCount", Collections.singletonList(Statistics.COUNT)),
+
+    /**
+     * For each thread defined in {@link
+     * org.opensearch.performanceanalyzer.PerformanceAnalyzerThreads}, we add a respective
+     * 'threadExceptionCode' metric. These metrics are emitted in catch block of {@link
+     * org.opensearch.performanceanalyzer.threads.ThreadProvider#createThreadForRunnable}
+     */
+    READER_THREAD_STOPPED(
+            "ReaderThreadStopped", "count", Collections.singletonList(Statistics.COUNT)),
+
+    ERROR_HANDLER_THREAD_STOPPED(
+            "ErrorHandlerThreadStopped", "count", Collections.singletonList(Statistics.COUNT)),
+
+    GRPC_SERVER_THREAD_STOPPED(
+            "GRPCServerThreadStopped", "count", Collections.singletonList(Statistics.COUNT)),
+
+    WEB_SERVER_THREAD_STOPPED(
+            "WebServerThreadStopped", "count", Collections.singletonList(Statistics.COUNT)),
+
+    RCA_CONTROLLER_THREAD_STOPPED(
+            "RcaControllerThreadStopped", "count", Collections.singletonList(Statistics.COUNT)),
+
+    RCA_SCHEDULER_THREAD_STOPPED(
+            "RcaSchedulerThreadStopped", "count", Collections.singletonList(Statistics.COUNT)),
+
+    /** Tracks time taken by Reader thread to emit event metrics . */
+    READER_METRICS_EMIT_TIME(
+            "ReaderMetricsEmitTime",
+            "millis",
+            Arrays.asList(Statistics.MAX, Statistics.MEAN, Statistics.SUM)),
+
+    /**
+     * Tracks scheduler restart issued at {@link
+     * org.opensearch.performanceanalyzer.rca.RcaController#restart}
+     */
+    RCA_SCHEDULER_RESTART(
+            "RcaSchedulerRestart", "count", Collections.singletonList(Statistics.COUNT)),
+
     /** Size of generated metricsdb files. */
     METRICSDB_FILE_SIZE(
             "MetricsdbFileSize", "bytes", Arrays.asList(Statistics.MAX, Statistics.MEAN)),
@@ -106,7 +154,14 @@ public enum ReaderMetrics implements MeasurementSet {
                     Statistics.MIN,
                     Statistics.MEAN,
                     Statistics.COUNT,
-                    Statistics.SUM));
+                    Statistics.SUM)),
+
+    /**
+     * A blanket exception code for {@link
+     * org.opensearch.performanceanalyzer.reader.ReaderMetricsProcessor} failures.
+     */
+    OTHER("Other", "count", Collections.singletonList(Statistics.COUNT));
+
     /** What we want to appear as the metric name. */
     private String name;
 

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/framework/metrics/WriterMetrics.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/framework/metrics/WriterMetrics.java
@@ -70,10 +70,15 @@ public enum WriterMetrics implements MeasurementSet {
     JVM_THREAD_ID_NO_LONGER_EXISTS("JVMThreadIdNoLongerExists"),
 
     /** Tracks the number of muted collectors */
-    COLLECTORS_MUTED("CollectorsMutedCount"),
+    COLLECTORS_MUTED(
+            "CollectorsMutedCount",
+            "namedCount",
+            Collections.singletonList(Statistics.NAMED_COUNTERS)),
 
+    /** This metric indicates faiure in collecting MasterServiceEventMetrics */
     MASTER_METRICS_ERROR("MasterMetricsError"),
-    MASTER_NODE_NOT_UP("MasterNodeNotUp"),
+
+    /** This metric indicates faiure in intercepting opensearch requests at transport channel */
     OPENSEARCH_REQUEST_INTERCEPTOR_ERROR("OpenSearchRequestInterceptorError"),
 
     /** Collector specific metrics */
@@ -191,13 +196,16 @@ public enum WriterMetrics implements MeasurementSet {
     WRITER_FILE_CREATION_SKIPPED(
             "WriterFileCreationSkipped", "count", Arrays.asList(Statistics.COUNT)),
 
+    /** This metric indicates metric entry insertion to event log queue failed */
     METRICS_WRITE_ERROR(
             "MetricsWriteError",
             "namedCount",
             Collections.singletonList(Statistics.NAMED_COUNTERS)),
 
+    /** This metric indicates faiure in cleaning up the event log files */
     METRICS_REMOVE_ERROR("MetricsRemoveError", "count", Arrays.asList(Statistics.COUNT)),
 
+    /** This metric indicates faiure in cleaning up the event log files */
     METRICS_REMOVE_FAILURE("MetricsRemoveFailure", "count", Arrays.asList(Statistics.COUNT)),
     ;
 

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/framework/metrics/WriterMetrics.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/framework/metrics/WriterMetrics.java
@@ -43,6 +43,40 @@ public enum WriterMetrics implements MeasurementSet {
     EVENT_LOG_FILES_DELETED(
             "EventLogFilesDeleted", "count", Arrays.asList(Statistics.MAX, Statistics.SUM)),
 
+    /** Metrics tracking Plugin level: 1. Errors 2. Exceptions */
+
+    /** Tracks stale metrics - metrics to be collected is behind current bucket */
+    STALE_METRICS("StaleMetrics"),
+
+    /** Tracks the number of VM attach/dataDump or detach failures. */
+    JVM_ATTACH_ERROR("JvmAttachErrror"),
+
+    /** java_pid file is missing. */
+    JVM_ATTACH_ERROR_JAVA_PID_FILE_MISSING("JvmAttachErrorJavaPidFileMissing"),
+
+    /** Lock could not be acquired within the timeout. */
+    JVM_ATTACH_LOCK_ACQUISITION_FAILED("JvmAttachLockAcquisitionFailed"),
+
+    /** ThreadState could not be found for an OpenSearch thread in the critical OpenSearch path. */
+    NO_THREAD_STATE_INFO("NoThreadStateInfo"),
+
+    /**
+     * Successfully completed a thread-dump. An omission of indicate thread taking the dump got
+     * stuck.
+     */
+    JVM_THREAD_DUMP_SUCCESSFUL("JvmThreadDumpSuccessful"),
+
+    /** Thread ID is no loner exists */
+    JVM_THREAD_ID_NO_LONGER_EXISTS("JVMThreadIdNoLongerExists"),
+
+    /** Tracks the number of muted collectors */
+    COLLECTORS_MUTED("CollectorsMutedCount"),
+
+    MASTER_METRICS_ERROR("MasterMetricsError"),
+    MASTER_NODE_NOT_UP("MasterNodeNotUp"),
+    OPENSEARCH_REQUEST_INTERCEPTOR_ERROR("OpenSearchRequestInterceptorError"),
+
+    /** Collector specific metrics */
     SHARD_STATE_COLLECTOR_EXECUTION_TIME(
             "ShardStateCollectorExecutionTime",
             "millis",
@@ -153,8 +187,6 @@ public enum WriterMetrics implements MeasurementSet {
                     Statistics.COUNT,
                     Statistics.SUM)),
 
-    STALE_METRICS("StaleMetrics", "count", Arrays.asList(Statistics.COUNT)),
-
     /** This metric indicates that the writer file creation was skipped. */
     WRITER_FILE_CREATION_SKIPPED(
             "WriterFileCreationSkipped", "count", Arrays.asList(Statistics.COUNT)),
@@ -183,6 +215,12 @@ public enum WriterMetrics implements MeasurementSet {
      * collection of one or more such statistics.
      */
     private List<Statistics> statsList;
+
+    WriterMetrics(String name) {
+        this.name = name;
+        this.unit = "count";
+        this.statsList = Collections.singletonList(Statistics.COUNT);
+    }
 
     WriterMetrics(String name, String unit, List<Statistics> stats) {
         this.name = name;

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/framework/util/RcaConsts.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/framework/util/RcaConsts.java
@@ -34,11 +34,9 @@ import org.opensearch.performanceanalyzer.core.Util;
 public class RcaConsts {
 
     public static final String RCA_CONF_MASTER_FILENAME = "rca_master.conf";
-    public static final String VERTEX_BUFFER_FULL_METRIC = "RcaVertexBufferFull";
     public static final String RCA_NETWORK_THREAD_NAME_FORMAT = "rca-net-%d";
     public static final int NETWORK_CORE_THREAD_COUNT = 1;
     public static final int NETWORK_MAX_THREAD_COUNT = 1;
-    public static final String RCA_SCHEDULER_RESTART_METRIC = "RcaSchedulerRestart";
     public static final int DEFAULT_PER_NODE_FLOWUNIT_Q_SIZE = 200;
     public static final long RCA_STATE_CHECK_INTERVAL_IN_MS = 5000;
     private static final String RCA_CONF_FILENAME = "rca.conf";
@@ -54,9 +52,6 @@ public class RcaConsts {
             Paths.get(CONFIG_DIR_PATH, RCA_CONF_IDLE_MASTER_FILENAME).toString();
     public static final String THRESHOLDS_PATH =
             Paths.get(CONFIG_DIR_PATH, THRESHOLDS_DIR_NAME).toString();
-    public static final String MUTE_ERROR_METRIC = "MuteError";
-    public static final String HOT_SHARD_RCA_ERROR_METRIC = "HotShardError";
-    public static final String WRITE_UPDATED_RCA_CONF_ERROR = "WriteUpdatedRcaConfError";
 
     static final String dir = System.getProperty("user.dir");
     public static final String TEST_CONFIG_PATH =

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/net/tasks/FlowUnitRxTask.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/net/tasks/FlowUnitRxTask.java
@@ -30,11 +30,9 @@ package org.opensearch.performanceanalyzer.rca.net.tasks;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.performanceanalyzer.PerformanceAnalyzerApp;
-import org.opensearch.performanceanalyzer.collectors.StatsCollector;
 import org.opensearch.performanceanalyzer.grpc.FlowUnitMessage;
 import org.opensearch.performanceanalyzer.rca.framework.metrics.RcaGraphMetrics;
 import org.opensearch.performanceanalyzer.rca.framework.util.InstanceDetails;
-import org.opensearch.performanceanalyzer.rca.framework.util.RcaConsts;
 import org.opensearch.performanceanalyzer.rca.net.NodeStateManager;
 import org.opensearch.performanceanalyzer.rca.net.ReceivedFlowUnitStore;
 
@@ -76,9 +74,7 @@ public class FlowUnitRxTask implements Runnable {
             LOG.warn(
                     "Dropped a flow unit because the vertex buffer was full for vertex: {}",
                     vertex);
-            StatsCollector.instance().logMetric(RcaConsts.VERTEX_BUFFER_FULL_METRIC);
         }
-
         PerformanceAnalyzerApp.RCA_GRAPH_METRICS_AGGREGATOR.updateStat(
                 RcaGraphMetrics.RCA_NODES_FU_CONSUME_COUNT, vertex, 1);
     }

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/net/tasks/FlowUnitTxTask.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/net/tasks/FlowUnitTxTask.java
@@ -33,8 +33,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.performanceanalyzer.AppContext;
 import org.opensearch.performanceanalyzer.PerformanceAnalyzerApp;
-import org.opensearch.performanceanalyzer.collectors.StatExceptionCode;
-import org.opensearch.performanceanalyzer.collectors.StatsCollector;
 import org.opensearch.performanceanalyzer.grpc.PublishResponse;
 import org.opensearch.performanceanalyzer.grpc.PublishResponse.PublishResponseStatus;
 import org.opensearch.performanceanalyzer.net.NetClient;
@@ -108,9 +106,9 @@ public class FlowUnitTxTask implements Runnable {
 
                                 @Override
                                 public void onError(final Throwable t) {
+                                    PerformanceAnalyzerApp.RCA_GRAPH_METRICS_AGGREGATOR.updateStat(
+                                            RcaGraphMetrics.RCA_NETWORK_ERROR, sourceGraphNode, 1);
                                     LOG.error("rca: Encountered an exception at the server: ", t);
-                                    StatsCollector.instance()
-                                            .logException(StatExceptionCode.RCA_NETWORK_ERROR);
                                     subscriptionManager.unsubscribeAndTerminateConnection(
                                             sourceGraphNode, downstreamHostId);
                                     client.flushStream(downstreamHostId);

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/stats/RcaStatsReporter.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/stats/RcaStatsReporter.java
@@ -35,7 +35,8 @@ import org.opensearch.performanceanalyzer.rca.stats.measurements.MeasurementSet;
 
 /**
  * This is meant to be the registry for all the stats that are collected by the Rca framework and
- * needs to be reported periodically by the {@code StatsCollector.collectMetrics}
+ * needs to be reported periodically by the {@link
+ * org.opensearch.performanceanalyzer.collectors.StatsCollector#collectMetrics}
  */
 public class RcaStatsReporter {
     /** The list of collectors for which a report can be generated. */

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/hotshard/HotShardRca.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/hotshard/HotShardRca.java
@@ -37,7 +37,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jooq.Record;
-import org.opensearch.performanceanalyzer.collectors.StatsCollector;
+import org.opensearch.performanceanalyzer.PerformanceAnalyzerApp;
 import org.opensearch.performanceanalyzer.grpc.FlowUnitMessage;
 import org.opensearch.performanceanalyzer.metrics.AllMetrics;
 import org.opensearch.performanceanalyzer.metricsdb.MetricsDB;
@@ -53,8 +53,8 @@ import org.opensearch.performanceanalyzer.rca.framework.api.flow_units.ResourceF
 import org.opensearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
 import org.opensearch.performanceanalyzer.rca.framework.api.summaries.HotShardSummary;
 import org.opensearch.performanceanalyzer.rca.framework.core.RcaConf;
+import org.opensearch.performanceanalyzer.rca.framework.metrics.RcaVerticesMetrics;
 import org.opensearch.performanceanalyzer.rca.framework.util.InstanceDetails;
-import org.opensearch.performanceanalyzer.rca.framework.util.RcaConsts;
 import org.opensearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
 
 /**
@@ -136,8 +136,9 @@ public class HotShardRca extends Rca<ResourceFlowUnit<HotNodeSummary>> {
                     usageDeque.next(new SlidingWindowData(this.clock.millis(), usage));
                 }
             } catch (Exception e) {
-                StatsCollector.instance().logMetric(RcaConsts.HOT_SHARD_RCA_ERROR_METRIC);
-                LOG.error("Failed to parse metric in FlowUnit: {} from {}", record, metricType);
+                PerformanceAnalyzerApp.RCA_VERTICES_METRICS_AGGREGATOR.updateStat(
+                        RcaVerticesMetrics.HOT_SHARD_RCA_ERROR, "", 1);
+                LOG.error("Failed to parse metric in FlowUnit: {} from {}", record, metricType, e);
             }
         }
     }

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/jvmsizing/HighOldGenOccupancyRca.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/jvmsizing/HighOldGenOccupancyRca.java
@@ -30,8 +30,7 @@ package org.opensearch.performanceanalyzer.rca.store.rca.jvmsizing;
 import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.performanceanalyzer.collectors.StatExceptionCode;
-import org.opensearch.performanceanalyzer.collectors.StatsCollector;
+import org.opensearch.performanceanalyzer.PerformanceAnalyzerApp;
 import org.opensearch.performanceanalyzer.rca.configs.HighOldGenOccupancyRcaConfig;
 import org.opensearch.performanceanalyzer.rca.framework.api.Metric;
 import org.opensearch.performanceanalyzer.rca.framework.api.Resources;
@@ -42,13 +41,13 @@ import org.opensearch.performanceanalyzer.rca.framework.api.flow_units.ResourceF
 import org.opensearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
 import org.opensearch.performanceanalyzer.rca.framework.api.summaries.ResourceUtil;
 import org.opensearch.performanceanalyzer.rca.framework.core.RcaConf;
+import org.opensearch.performanceanalyzer.rca.framework.metrics.RcaVerticesMetrics;
 import org.opensearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
 import org.opensearch.performanceanalyzer.rca.store.rca.OldGenRca;
 
 public class HighOldGenOccupancyRca extends OldGenRca<ResourceFlowUnit<HotResourceSummary>> {
 
     private static final Logger LOG = LogManager.getLogger(HighOldGenOccupancyRca.class);
-    private static final String OLD_GEN_OVER_OCCUPIED_METRIC = "OldGenOverOccupied";
     private static final long EVAL_INTERVAL_IN_S = 5;
     private static final int B_TO_MB = 1024 * 1024;
 
@@ -135,7 +134,8 @@ public class HighOldGenOccupancyRca extends OldGenRca<ResourceFlowUnit<HotResour
                         averageUtilizationPercentage,
                         (int) rcaEvaluationIntervalInS);
         if (averageUtilizationPercentage >= heapUtilizationThreshold) {
-            StatsCollector.instance().logMetric(OLD_GEN_OVER_OCCUPIED_METRIC);
+            PerformanceAnalyzerApp.RCA_VERTICES_METRICS_AGGREGATOR.updateStat(
+                    RcaVerticesMetrics.OLD_GEN_OVER_OCCUPIED, "", 1);
             context = new ResourceContext(Resources.State.UNHEALTHY);
         }
         this.previousSummary = summary;
@@ -148,9 +148,9 @@ public class HighOldGenOccupancyRca extends OldGenRca<ResourceFlowUnit<HotResour
         double maxOldGen = getMaxOldGenSizeOrDefault(Double.MAX_VALUE);
 
         if (maxOldGen == 0d) {
+            PerformanceAnalyzerApp.RCA_VERTICES_METRICS_AGGREGATOR.updateStat(
+                    RcaVerticesMetrics.INVALID_OLD_GEN_SIZE, "", 1);
             LOG.info("Max Old Gen capacity cannot be 0. Skipping.");
-
-            StatsCollector.instance().logException(StatExceptionCode.INVALID_OLD_GEN_SIZE);
             return;
         }
 

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/jvmsizing/OldGenContendedRca.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/jvmsizing/OldGenContendedRca.java
@@ -32,7 +32,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.performanceanalyzer.collectors.StatsCollector;
+import org.opensearch.performanceanalyzer.PerformanceAnalyzerApp;
 import org.opensearch.performanceanalyzer.grpc.FlowUnitMessage;
 import org.opensearch.performanceanalyzer.rca.configs.OldGenContendedRcaConfig;
 import org.opensearch.performanceanalyzer.rca.framework.api.Rca;
@@ -42,6 +42,7 @@ import org.opensearch.performanceanalyzer.rca.framework.api.flow_units.ResourceF
 import org.opensearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
 import org.opensearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
 import org.opensearch.performanceanalyzer.rca.framework.core.RcaConf;
+import org.opensearch.performanceanalyzer.rca.framework.metrics.RcaVerticesMetrics;
 import org.opensearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import org.opensearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
 import org.opensearch.performanceanalyzer.rca.util.MemInfoParser;
@@ -49,7 +50,6 @@ import org.opensearch.performanceanalyzer.rca.util.MemInfoParser;
 public class OldGenContendedRca extends Rca<ResourceFlowUnit<HotNodeSummary>> {
 
     private static final Logger LOG = LogManager.getLogger(OldGenContendedRca.class);
-    private static final String OLD_GEN_CONTENDED_METRIC = "OldGenContended";
     private static final long GB_TO_B = 1024 * 1024 * 1024;
     private static final long EVAL_INTERVAL_IN_S = 5;
     private Rca<ResourceFlowUnit<HotResourceSummary>> highOldGenOccupancyRca;
@@ -124,7 +124,8 @@ public class OldGenContendedRca extends Rca<ResourceFlowUnit<HotNodeSummary>> {
                 summary.appendNestedSummary(oldGenReclamationFlowUnit.getSummary());
 
                 ResourceContext context = new ResourceContext(Resources.State.CONTENDED);
-                StatsCollector.instance().logMetric(OLD_GEN_CONTENDED_METRIC);
+                PerformanceAnalyzerApp.RCA_VERTICES_METRICS_AGGREGATOR.updateStat(
+                        RcaVerticesMetrics.OLD_GEN_CONTENDED, "", 1);
                 return new ResourceFlowUnit<>(currTime, context, summary);
             }
         }

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/jvmsizing/OldGenReclamationRca.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/jvmsizing/OldGenReclamationRca.java
@@ -28,7 +28,7 @@ package org.opensearch.performanceanalyzer.rca.store.rca.jvmsizing;
 
 
 import java.util.concurrent.TimeUnit;
-import org.opensearch.performanceanalyzer.collectors.StatsCollector;
+import org.opensearch.performanceanalyzer.PerformanceAnalyzerApp;
 import org.opensearch.performanceanalyzer.rca.framework.api.Metric;
 import org.opensearch.performanceanalyzer.rca.framework.api.Resources;
 import org.opensearch.performanceanalyzer.rca.framework.api.aggregators.SlidingWindow;
@@ -37,13 +37,12 @@ import org.opensearch.performanceanalyzer.rca.framework.api.contexts.ResourceCon
 import org.opensearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
 import org.opensearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
 import org.opensearch.performanceanalyzer.rca.framework.api.summaries.ResourceUtil;
+import org.opensearch.performanceanalyzer.rca.framework.metrics.RcaVerticesMetrics;
 import org.opensearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
 import org.opensearch.performanceanalyzer.rca.store.rca.OldGenRca;
 
 public class OldGenReclamationRca extends OldGenRca<ResourceFlowUnit<HotResourceSummary>> {
 
-    private static final String OLD_GEN_RECLAMATION_INEFFECTIVE_METRIC =
-            "OldGenReclamationIneffective";
     private static final long EVAL_INTERVAL_IN_S = 5;
     private static final double DEFAULT_TARGET_UTILIZATION_AFTER_GC = 75.0d;
     private static final int DEFAULT_RCA_EVALUATION_INTERVAL_IN_S = 60;
@@ -127,7 +126,8 @@ public class OldGenReclamationRca extends OldGenRca<ResourceFlowUnit<HotResource
                                     minOldGenSlidingWindow.readMin(),
                                     rcaEvaluationIntervalInS);
                     context = new ResourceContext(Resources.State.UNHEALTHY);
-                    StatsCollector.instance().logMetric(OLD_GEN_RECLAMATION_INEFFECTIVE_METRIC);
+                    PerformanceAnalyzerApp.RCA_VERTICES_METRICS_AGGREGATOR.updateStat(
+                            RcaVerticesMetrics.OLD_GEN_RECLAMATION_INEFFECTIVE, "", 1);
                     prevSummary = summary;
                     prevContext = context;
                     return new ResourceFlowUnit<>(currTime, context, summary);

--- a/src/main/java/org/opensearch/performanceanalyzer/threads/exceptions/PAThreadException.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/threads/exceptions/PAThreadException.java
@@ -28,7 +28,7 @@ package org.opensearch.performanceanalyzer.threads.exceptions;
 
 
 import org.opensearch.performanceanalyzer.PerformanceAnalyzerThreads;
-import org.opensearch.performanceanalyzer.collectors.StatExceptionCode;
+import org.opensearch.performanceanalyzer.rca.stats.measurements.MeasurementSet;
 
 /** Exception that is thrown when one of the PA threads run into an unhandled exception. */
 public class PAThreadException extends Exception {
@@ -54,9 +54,9 @@ public class PAThreadException extends Exception {
     /**
      * Gets the counter against which we need to record an error metric.
      *
-     * @return The {@link StatExceptionCode} enum value that represents the error metric name.
+     * @return The {@link MeasurementSet} enum value that represents the error metric name.
      */
-    public StatExceptionCode getExceptionCode() {
+    public MeasurementSet getExceptionCode() {
         return paThread.getThreadExceptionCode();
     }
 

--- a/src/main/java/org/opensearch/performanceanalyzer/util/FileHelper.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/util/FileHelper.java
@@ -32,9 +32,9 @@ import java.io.File;
 import java.io.FileReader;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.performanceanalyzer.collectors.StatExceptionCode;
-import org.opensearch.performanceanalyzer.collectors.StatsCollector;
+import org.opensearch.performanceanalyzer.PerformanceAnalyzerApp;
 import org.opensearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
+import org.opensearch.performanceanalyzer.rca.framework.metrics.ReaderMetrics;
 
 public class FileHelper {
     private static final Logger log = LogManager.getLogger(FileHelper.class);
@@ -78,11 +78,11 @@ public class FileHelper {
                 }
             }
         } catch (Exception ex) {
-            StatsCollector.instance().logException();
+            PerformanceAnalyzerApp.READER_METRICS_AGGREGATOR.updateStat(ReaderMetrics.OTHER, "", 1);
             log.debug(
-                    "Having issue to read current time from the content of file. Using file metadata; excpetion: {} ExceptionCode: {}",
+                    "Having issue to read current time from the content of file. Using file metadata; exception: {} ExceptionCode: {}",
                     () -> ex,
-                    () -> StatExceptionCode.OTHER.toString());
+                    () -> ReaderMetrics.OTHER.toString());
         }
         return file.lastModified();
     }

--- a/src/test/java/org/opensearch/performanceanalyzer/jvm/ThreadListTest.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/jvm/ThreadListTest.java
@@ -28,14 +28,9 @@ package org.opensearch.performanceanalyzer.jvm;
 
 
 import java.lang.management.ThreadInfo;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.opensearch.performanceanalyzer.OSMetricsGeneratorFactory;
-import org.opensearch.performanceanalyzer.collectors.StatExceptionCode;
-import org.opensearch.performanceanalyzer.collectors.StatsCollector;
 
 // This test only runs in linux systems as the some of the static members of the ThreadList
 // class are specific to Linux.
@@ -57,10 +52,10 @@ public class ThreadListTest {
 
         ThreadList.parseAllThreadInfos(infos);
 
-        Map<String, AtomicInteger> counters = StatsCollector.instance().getCounters();
+        /*Map<String, AtomicInteger> counters = StatsCollector.instance().getCounters();
 
         Assert.assertEquals(
-                counters.get(StatExceptionCode.JVM_THREAD_ID_NO_LONGER_EXISTS.toString()).get(), 1);
+                counters.get(PerformanceAnalyzerApp.WRITER_METRICS_AGGREGATOR.getValues(WriterMetrics.JVM_THREAD_ID_NO_LONGER_EXISTS).toString()).get(), 1);*/
 
         if (old_clk_tck != null) {
             System.setProperty(propertyName, old_clk_tck);

--- a/src/test/java/org/opensearch/performanceanalyzer/jvm/ThreadListTest.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/jvm/ThreadListTest.java
@@ -28,9 +28,12 @@ package org.opensearch.performanceanalyzer.jvm;
 
 
 import java.lang.management.ThreadInfo;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.opensearch.performanceanalyzer.OSMetricsGeneratorFactory;
+import org.opensearch.performanceanalyzer.rca.RcaTestHelper;
+import org.opensearch.performanceanalyzer.rca.framework.metrics.WriterMetrics;
 
 // This test only runs in linux systems as the some of the static members of the ThreadList
 // class are specific to Linux.
@@ -41,7 +44,7 @@ public class ThreadListTest {
     }
 
     @Test
-    public void testNullThreadInfo() {
+    public void testNullThreadInfo() throws InterruptedException {
         String propertyName = "clk.tck";
         String old_clk_tck = System.getProperty(propertyName);
         System.setProperty(propertyName, "100");
@@ -51,12 +54,7 @@ public class ThreadListTest {
         infos[0] = null;
 
         ThreadList.parseAllThreadInfos(infos);
-
-        /*Map<String, AtomicInteger> counters = StatsCollector.instance().getCounters();
-
-        Assert.assertEquals(
-                counters.get(PerformanceAnalyzerApp.WRITER_METRICS_AGGREGATOR.getValues(WriterMetrics.JVM_THREAD_ID_NO_LONGER_EXISTS).toString()).get(), 1);*/
-
+        Assert.assertTrue(RcaTestHelper.verify(WriterMetrics.JVM_THREAD_ID_NO_LONGER_EXISTS));
         if (old_clk_tck != null) {
             System.setProperty(propertyName, old_clk_tck);
         }


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
`StatsCollector` is used by RCA-Agent and PerformanceAnalyzer Plugin to publish service metrics. We run this collector through `ScheduledMetricCollectorsExecutor` and the executor can mark the collector as SLOW and subsequently MUTED if the collector is slow. A muted collector doesn't emit any metrics and thus we can end up missing the helpful service metrics.

This PR contains changes to skip muting for  `StatsCollector` and re-factoring to move away from `StatExceptionCode` to Metric Aggregators. 

Adding more granular code change details:
* PerformanceAnalyzerApp.java : Removing Default Exception code. (Moving to Aggregator metric framework, does not require default codes)
* PerformanceAnalyzerThreads.java : Moved Thread failure exception codes to `ReaderMetrics`. Each time a thread dies, the respective metric will be emitted via the catch block in `ThreadProvider#createThreadForRunnable()`
* ScheduledMetricCollectorsExecutor.java : `StatsCollector` is now non-mutable. This is required to ensure that we always have service metrics available to debug issues.
* StatExceptionCode.java : Moved exception codes to relevant Aggregators. 
* StatsCollector.java :  Removed `logMetric(final String metricName)` and `logException()`. 
* FlowUnitRxTask.java : Removing duplicate metric `VERTEX_BUFFER_FULL_METRIC`. We emit `RCA_VERTEX_RX_BUFFER_FULL_ERROR` in ReceivedFlowUnitStore.
* ReaderMetricsProcessor.java : Emitting `READER_METRICS_EMIT_TIME` instead of using older `TIMING_STATS` and `STATS_DATA` data structure.


**Describe the solution you are proposing**
A clear and concise description of what you want to happen.

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
