### PR TITLE
Fix thread name categorizations for Operation dimension in metrics API

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/reader/MetricsEmitter.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/reader/MetricsEmitter.java
@@ -78,10 +78,8 @@ public class MetricsEmitter {
     // Pattern otherPattern = Pattern.compile(".*(opensearch).*");
     private static final Pattern HTTP_SERVER_PATTERN =
             Pattern.compile(".*opensearch.*\\[http_server_worker\\].*");
-    private static final Pattern TRANS_SERVER_PATTERN =
-            Pattern.compile(".*opensearch.*\\[transport_server_worker.*");
-    private static final Pattern TRANS_CLIENT_PATTERN =
-            Pattern.compile(".*opensearch.*\\[transport_client_boss\\].*");
+    private static final Pattern TRANS_WORKER_PATTERN =
+            Pattern.compile(".*opensearch.*\\[transport_worker.*");
 
     private static final List<String> LATENCY_TABLE_DIMENSIONS =
             new ArrayList<String>() {
@@ -537,11 +535,8 @@ public class MetricsEmitter {
         if (HTTP_SERVER_PATTERN.matcher(threadName).matches()) {
             return "httpServer";
         }
-        if (TRANS_CLIENT_PATTERN.matcher(threadName).matches()) {
-            return "transportClient";
-        }
-        if (TRANS_SERVER_PATTERN.matcher(threadName).matches()) {
-            return "transportServer";
+        if (TRANS_WORKER_PATTERN.matcher(threadName).matches()) {
+            return "transportWorker";
         }
         if (GENERIC_PATTERN.matcher(threadName).matches()) {
             return "generic";

--- a/src/main/java/org/opensearch/performanceanalyzer/reader/MetricsEmitter.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/reader/MetricsEmitter.java
@@ -516,11 +516,11 @@ public class MetricsEmitter {
         // emitWorkloadMetrics functions.
         // Hence these are ignored in this emitter.
         if (SEARCH_PATTERN.matcher(threadName).matches()) {
-            return null;
+            return "search";
         }
         if (BULK_PATTERN.matcher(threadName).matches()
                 || WRITE_PATTERN.matcher(threadName).matches()) {
-            return null;
+            return "write";
         }
 
         if (GC_PATTERN.matcher(threadName).matches()) {

--- a/src/test/java/org/opensearch/performanceanalyzer/reader/MetricsEmitterTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/reader/MetricsEmitterTests.java
@@ -338,7 +338,7 @@ public class MetricsEmitterTests extends AbstractReaderTests {
                 MetricsEmitter.categorizeThreadName(
                         "Gang worker#0 (Parallel GC Threads)", dimensions));
         assertEquals(
-                null,
+                "search",
                 MetricsEmitter.categorizeThreadName(
                         "opensearch[I9AByra][search][T#4]", dimensions));
         assertEquals(
@@ -353,10 +353,10 @@ public class MetricsEmitterTests extends AbstractReaderTests {
                 "management",
                 MetricsEmitter.categorizeThreadName("opensearch[I9AByra][management]", dimensions));
         assertEquals(
-                null,
+                "search",
                 MetricsEmitter.categorizeThreadName("opensearch[I9AByra][search]", dimensions));
         assertEquals(
-                null, MetricsEmitter.categorizeThreadName("opensearch[I9AByra][bulk]", dimensions));
+                "write", MetricsEmitter.categorizeThreadName("opensearch[I9AByra][bulk]", dimensions));
         assertEquals("other", MetricsEmitter.categorizeThreadName("Top thread random", dimensions));
     }
 

--- a/src/test/resources/reader/1566413960000
+++ b/src/test/resources/reader/1566413960000
@@ -4962,7 +4962,7 @@ Sched_Runtime:1.1665423333333335E-4
 Sched_Waittime:2.669033333333333E-6
 Sched_CtxRate:5.9988002399520095
 Heap_AllocRate:17241.04820964193
-threadName:opensearch[4sqG_AP][[transport_server_worker.default]][T#1]
+threadName:opensearch[4sqG_AP][[transport_worker]][T#1]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:1954
 IO_ReadThroughput:0.0
@@ -4981,7 +4981,7 @@ Sched_Runtime:2.73064E-5
 Sched_Waittime:6.0E-6
 Sched_CtxRate:0.9998000399920015
 Heap_AllocRate:0.0
-threadName:opensearch[4sqG_AP][[transport_server_worker.default]][T#2]
+threadName:opensearch[4sqG_AP][[transport_worker]][T#2]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:0
 IO_ReadThroughput:0.0
@@ -5019,7 +5019,7 @@ Sched_Runtime:1.466476666666667E-4
 Sched_Waittime:2.98480037037037E-4
 Sched_CtxRate:5.398920215956808
 Heap_AllocRate:97535.50710142028
-threadName:opensearch[4sqG_AP][transport_client_boss][T#5]
+threadName:opensearch[4sqG_AP][transport_worker][T#5]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:654
 IO_ReadThroughput:0.0
@@ -5038,7 +5038,7 @@ Sched_Runtime:1.4930206896551724E-4
 Sched_Waittime:2.7944482758620692E-6
 Sched_CtxRate:5.7988402319536085
 Heap_AllocRate:24936.987397479497
-threadName:opensearch[4sqG_AP][[transport_server_worker.default]][T#7]
+threadName:opensearch[4sqG_AP][[transport_worker]][T#7]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:1910
 IO_ReadThroughput:0.0
@@ -5076,7 +5076,7 @@ Sched_Runtime:1.0272144444444444E-4
 Sched_Waittime:6.020814814814816E-6
 Sched_CtxRate:5.398920215956808
 Heap_AllocRate:48048.009601920385
-threadName:opensearch[4sqG_AP][transport_client_boss][T#3]
+threadName:opensearch[4sqG_AP][transport_worker][T#3]
 Thread_Blocked_Time:0.016666666666666666
 Thread_Blocked_Event:194466
 IO_ReadThroughput:0.0
@@ -5114,7 +5114,7 @@ Sched_Runtime:2.3673000000000002E-5
 Sched_Waittime:5.5038000000000006E-6
 Sched_CtxRate:0.9998000399920015
 Heap_AllocRate:0.0
-threadName:opensearch[4sqG_AP][[transport_server_worker.default]][T#3]
+threadName:opensearch[4sqG_AP][[transport_worker]][T#3]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:7
 IO_ReadThroughput:0.0
@@ -5186,7 +5186,7 @@ Sched_Runtime:1.1943521052631579E-4
 Sched_Waittime:1.1412234210526317E-4
 Sched_CtxRate:7.598480303939212
 Heap_AllocRate:17358.67173434687
-threadName:opensearch[4sqG_AP][transport_client_boss][T#4]
+threadName:opensearch[4sqG_AP][transport_worker][T#4]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:658
 IO_ReadThroughput:0.0
@@ -5224,7 +5224,7 @@ Sched_Runtime:1.2357226666666668E-4
 Sched_Waittime:2.4448666666666667E-6
 Sched_CtxRate:5.9988002399520095
 Heap_AllocRate:18296.459291858373
-threadName:opensearch[4sqG_AP][[transport_server_worker.default]][T#6]
+threadName:opensearch[4sqG_AP][[transport_worker]][T#6]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:32227
 IO_ReadThroughput:0.0
@@ -5262,7 +5262,7 @@ Sched_Runtime:2.311E-5
 Sched_Waittime:8.2522E-6
 Sched_CtxRate:0.9998000399920015
 Heap_AllocRate:0.0
-threadName:opensearch[4sqG_AP][transport_client_boss][T#6]
+threadName:opensearch[4sqG_AP][transport_worker][T#6]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:2
 IO_ReadThroughput:0.0
@@ -5528,7 +5528,7 @@ Sched_Runtime:9.317571428571429E-5
 Sched_Waittime:1.3278857142857142E-6
 Sched_CtxRate:6.998600279944011
 Heap_AllocRate:18368.473694738947
-threadName:opensearch[4sqG_AP][[transport_server_worker.default]][T#5]
+threadName:opensearch[4sqG_AP][[transport_worker]][T#5]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:32004
 IO_ReadThroughput:0.0
@@ -9794,7 +9794,7 @@ Sched_Runtime:1.9597691304347828E-4
 Sched_Waittime:3.802240869565217E-4
 Sched_CtxRate:4.599080183963207
 Heap_AllocRate:47531.10622124425
-threadName:opensearch[4sqG_AP][transport_client_boss][T#2]
+threadName:opensearch[4sqG_AP][transport_worker][T#2]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:196233
 IO_ReadThroughput:0.0
@@ -9813,7 +9813,7 @@ Sched_Runtime:1.3242228E-4
 Sched_Waittime:3.9910176000000007E-4
 Sched_CtxRate:4.999000199960007
 Heap_AllocRate:17249.04980996199
-threadName:opensearch[4sqG_AP][[transport_server_worker.default]][T#8]
+threadName:opensearch[4sqG_AP][[transport_worker]][T#8]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:31784
 IO_ReadThroughput:0.0
@@ -9946,7 +9946,7 @@ Sched_Runtime:1.4762006896551724E-4
 Sched_Waittime:3.422519655172414E-4
 Sched_CtxRate:5.7988402319536085
 Heap_AllocRate:146714.94298859773
-threadName:opensearch[4sqG_AP][transport_client_boss][T#1]
+threadName:opensearch[4sqG_AP][transport_worker][T#1]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:194813
 IO_ReadThroughput:0.0
@@ -10060,7 +10060,7 @@ Sched_Runtime:9.937632352941178E-5
 Sched_Waittime:2.8160891176470587E-4
 Sched_CtxRate:6.798640271945611
 Heap_AllocRate:17634.726945389077
-threadName:opensearch[4sqG_AP][[transport_server_worker.default]][T#4]
+threadName:opensearch[4sqG_AP][[transport_worker]][T#4]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:1938
 IO_ReadThroughput:0.0
@@ -10174,7 +10174,7 @@ Sched_Runtime:2.5530600000000003E-5
 Sched_Waittime:4.507200000000001E-6
 Sched_CtxRate:0.9998000399920015
 Heap_AllocRate:0.0
-threadName:opensearch[4sqG_AP][transport_client_boss][T#7]
+threadName:opensearch[4sqG_AP][transport_worker][T#7]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:1
 IO_ReadThroughput:0.0
@@ -10402,7 +10402,7 @@ Sched_Runtime:1.8373241666666667E-4
 Sched_Waittime:2.7324583333333336E-5
 Sched_CtxRate:4.799040191961607
 Heap_AllocRate:63805.56111222244
-threadName:opensearch[4sqG_AP][transport_client_boss][T#8]
+threadName:opensearch[4sqG_AP][transport_worker][T#8]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:625
 IO_ReadThroughput:0.0

--- a/src/test/resources/reader/1566413965000
+++ b/src/test/resources/reader/1566413965000
@@ -1232,7 +1232,7 @@ Sched_Runtime:1.0505025000000001E-4
 Sched_Waittime:9.114875000000001E-6
 Sched_CtxRate:1.597444089456869
 Heap_AllocRate:1294.2471235617809
-threadName:opensearch[4sqG_AP][[transport_server_worker.default]][T#1]
+threadName:opensearch[4sqG_AP][[transport_worker]][T#1]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:1959
 IO_ReadThroughput:0.0
@@ -1251,7 +1251,7 @@ Sched_Runtime:2.5541E-5
 Sched_Waittime:3.6084E-6
 Sched_CtxRate:0.9984025559105432
 Heap_AllocRate:0.0
-threadName:opensearch[4sqG_AP][[transport_server_worker.default]][T#2]
+threadName:opensearch[4sqG_AP][[transport_worker]][T#2]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:0
 IO_ReadThroughput:0.0
@@ -1289,7 +1289,7 @@ Sched_Runtime:1.0867103846153847E-4
 Sched_Waittime:2.2198653846153846E-6
 Sched_CtxRate:10.383386581469649
 Heap_AllocRate:44964.88244122061
-threadName:opensearch[4sqG_AP][transport_client_boss][T#5]
+threadName:opensearch[4sqG_AP][transport_worker][T#5]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:655
 IO_ReadThroughput:0.0
@@ -1308,7 +1308,7 @@ Sched_Runtime:2.299429E-4
 Sched_Waittime:6.015300000000001E-6
 Sched_CtxRate:1.9968051118210863
 Heap_AllocRate:11157.578789394698
-threadName:opensearch[4sqG_AP][[transport_server_worker.default]][T#7]
+threadName:opensearch[4sqG_AP][[transport_worker]][T#7]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:1913
 IO_ReadThroughput:0.0
@@ -1346,7 +1346,7 @@ Sched_Runtime:1.905752857142857E-4
 Sched_Waittime:8.562285714285715E-6
 Sched_CtxRate:1.3977635782747604
 Heap_AllocRate:43147.9739869935
-threadName:opensearch[4sqG_AP][transport_client_boss][T#3]
+threadName:opensearch[4sqG_AP][transport_worker][T#3]
 Thread_Blocked_Time:0.016666666666666666
 Thread_Blocked_Event:194470
 IO_ReadThroughput:0.0
@@ -1384,7 +1384,7 @@ Sched_Runtime:2.15612E-5
 Sched_Waittime:4.737800000000001E-6
 Sched_CtxRate:0.9984025559105432
 Heap_AllocRate:0.0
-threadName:opensearch[4sqG_AP][[transport_server_worker.default]][T#3]
+threadName:opensearch[4sqG_AP][[transport_worker]][T#3]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:7
 IO_ReadThroughput:0.0
@@ -1456,7 +1456,7 @@ Sched_Runtime:1.2917766666666668E-4
 Sched_Waittime:6.892333333333334E-6
 Sched_CtxRate:2.3961661341853033
 Heap_AllocRate:36619.90995497749
-threadName:opensearch[4sqG_AP][transport_client_boss][T#4]
+threadName:opensearch[4sqG_AP][transport_worker][T#4]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:660
 IO_ReadThroughput:0.0
@@ -1494,7 +1494,7 @@ Sched_Runtime:1.178909E-4
 Sched_Waittime:4.4990000000000005E-6
 Sched_CtxRate:1.9968051118210863
 Heap_AllocRate:618.7093546773386
-threadName:opensearch[4sqG_AP][[transport_server_worker.default]][T#6]
+threadName:opensearch[4sqG_AP][[transport_worker]][T#6]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:32231
 IO_ReadThroughput:0.0
@@ -1532,7 +1532,7 @@ Sched_Runtime:2.62108E-5
 Sched_Waittime:7.8414E-6
 Sched_CtxRate:0.9984025559105432
 Heap_AllocRate:0.0
-threadName:opensearch[4sqG_AP][transport_client_boss][T#6]
+threadName:opensearch[4sqG_AP][transport_worker][T#6]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:2
 IO_ReadThroughput:0.0
@@ -1808,7 +1808,7 @@ Sched_Runtime:1.2160590000000001E-4
 Sched_Waittime:3.5187E-6
 Sched_CtxRate:1.9968051118210863
 Heap_AllocRate:605.9029514757378
-threadName:opensearch[4sqG_AP][[transport_server_worker.default]][T#5]
+threadName:opensearch[4sqG_AP][[transport_worker]][T#5]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:32008
 IO_ReadThroughput:0.0
@@ -3168,7 +3168,7 @@ Sched_Runtime:2.196067142857143E-4
 Sched_Waittime:4.300571428571429E-6
 Sched_CtxRate:1.3977635782747604
 Heap_AllocRate:33954.57728864432
-threadName:opensearch[4sqG_AP][transport_client_boss][T#2]
+threadName:opensearch[4sqG_AP][transport_worker][T#2]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:196238
 IO_ReadThroughput:0.0
@@ -3187,7 +3187,7 @@ Sched_Runtime:1.0810857142857144E-4
 Sched_Waittime:5.049428571428572E-6
 Sched_CtxRate:1.3977635782747604
 Heap_AllocRate:1237.4187093546773
-threadName:opensearch[4sqG_AP][[transport_server_worker.default]][T#8]
+threadName:opensearch[4sqG_AP][[transport_worker]][T#8]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:31789
 IO_ReadThroughput:0.0
@@ -3320,7 +3320,7 @@ Sched_Runtime:2.4319000000000002E-5
 Sched_Waittime:1.1410200000000001E-5
 Sched_CtxRate:0.9984025559105432
 Heap_AllocRate:86261.53076538269
-threadName:opensearch[4sqG_AP][transport_client_boss][T#1]
+threadName:opensearch[4sqG_AP][transport_worker][T#1]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:194814
 IO_ReadThroughput:0.0
@@ -3434,7 +3434,7 @@ Sched_Runtime:9.900928571428573E-5
 Sched_Waittime:4.588285714285715E-6
 Sched_CtxRate:1.3977635782747604
 Heap_AllocRate:1237.4187093546773
-threadName:opensearch[4sqG_AP][[transport_server_worker.default]][T#4]
+threadName:opensearch[4sqG_AP][[transport_worker]][T#4]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:1945
 IO_ReadThroughput:0.0
@@ -3548,7 +3548,7 @@ Sched_Runtime:2.6876600000000003E-5
 Sched_Waittime:9.653400000000001E-6
 Sched_CtxRate:0.9984025559105432
 Heap_AllocRate:0.0
-threadName:opensearch[4sqG_AP][transport_client_boss][T#7]
+threadName:opensearch[4sqG_AP][transport_worker][T#7]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:1
 IO_ReadThroughput:0.0
@@ -3776,7 +3776,7 @@ Sched_Runtime:7.420930000000001E-5
 Sched_Waittime:1.8960000000000001E-6
 Sched_CtxRate:1.9968051118210863
 Heap_AllocRate:67909.15457728865
-threadName:opensearch[4sqG_AP][transport_client_boss][T#8]
+threadName:opensearch[4sqG_AP][transport_worker][T#8]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:626
 IO_ReadThroughput:0.0

--- a/src/test/resources/reader/1566413970000
+++ b/src/test/resources/reader/1566413970000
@@ -661,7 +661,7 @@ Sched_Runtime:1.8519714285714286E-5
 Sched_Waittime:1.1630014285714286E-4
 Sched_CtxRate:1.3637249172024157
 Heap_AllocRate:618.5855756727018
-threadName:opensearch[4sqG_AP][[transport_server_worker.default]][T#1]
+threadName:opensearch[4sqG_AP][[transport_worker]][T#1]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:1960
 IO_ReadThroughput:0.0
@@ -680,7 +680,7 @@ Sched_Runtime:8.7502E-6
 Sched_Waittime:3.0223720000000003E-4
 Sched_CtxRate:0.9740892265731541
 Heap_AllocRate:0.0
-threadName:opensearch[4sqG_AP][[transport_server_worker.default]][T#2]
+threadName:opensearch[4sqG_AP][[transport_worker]][T#2]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:0
 IO_ReadThroughput:0.0
@@ -737,7 +737,7 @@ Sched_Runtime:2.666374E-4
 Sched_Waittime:4.2874039999999997E-4
 Sched_CtxRate:1.9481784531463082
 Heap_AllocRate:83691.87675070028
-threadName:opensearch[4sqG_AP][transport_client_boss][T#5]
+threadName:opensearch[4sqG_AP][transport_worker][T#5]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:656
 IO_ReadThroughput:0.0
@@ -756,7 +756,7 @@ Sched_Runtime:1.4068725000000002E-4
 Sched_Waittime:0.0012375815833333334
 Sched_CtxRate:2.33781414377557
 Heap_AllocRate:8759.427828348504
-threadName:opensearch[4sqG_AP][[transport_server_worker.default]][T#7]
+threadName:opensearch[4sqG_AP][[transport_worker]][T#7]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:1915
 IO_ReadThroughput:0.0
@@ -794,7 +794,7 @@ Sched_Runtime:3.7749636619718315E-4
 Sched_Waittime:4.3497417183098594E-4
 Sched_CtxRate:138.3206701733879
 Heap_AllocRate:4.074050100040016E7
-threadName:opensearch[4sqG_AP][transport_client_boss][T#3]
+threadName:opensearch[4sqG_AP][transport_worker][T#3]
 Thread_Blocked_Time:0.016666666666666666
 Thread_Blocked_Event:194775
 IO_ReadThroughput:0.0
@@ -832,7 +832,7 @@ Sched_Runtime:1.09472E-5
 Sched_Waittime:0.0015578388
 Sched_CtxRate:0.9740892265731541
 Heap_AllocRate:0.0
-threadName:opensearch[4sqG_AP][[transport_server_worker.default]][T#3]
+threadName:opensearch[4sqG_AP][[transport_worker]][T#3]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:7
 IO_ReadThroughput:0.0
@@ -904,7 +904,7 @@ Sched_Runtime:2.4308162500000002E-4
 Sched_Waittime:6.326036875E-4
 Sched_CtxRate:3.117085525034093
 Heap_AllocRate:52068.82753101241
-threadName:opensearch[4sqG_AP][transport_client_boss][T#4]
+threadName:opensearch[4sqG_AP][transport_worker][T#4]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:660
 IO_ReadThroughput:0.0
@@ -942,7 +942,7 @@ Sched_Runtime:6.338912556818182E-4
 Sched_Waittime:5.867168352272728E-4
 Sched_CtxRate:34.28794077537503
 Heap_AllocRate:6087543.062918875
-threadName:opensearch[4sqG_AP][[transport_server_worker.default]][T#6]
+threadName:opensearch[4sqG_AP][[transport_worker]][T#6]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:32280
 IO_ReadThroughput:0.0
@@ -980,7 +980,7 @@ Sched_Runtime:1.28822E-5
 Sched_Waittime:2.873896E-4
 Sched_CtxRate:0.9740892265731541
 Heap_AllocRate:0.0
-threadName:opensearch[4sqG_AP][transport_client_boss][T#6]
+threadName:opensearch[4sqG_AP][transport_worker][T#6]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:2
 IO_ReadThroughput:0.0
@@ -6480,7 +6480,7 @@ Sched_Runtime:6.970349636363638E-4
 Sched_Waittime:6.119307515151515E-4
 Sched_CtxRate:32.144944476914084
 Heap_AllocRate:6211557.867360208
-threadName:opensearch[4sqG_AP][[transport_server_worker.default]][T#5]
+threadName:opensearch[4sqG_AP][[transport_worker]][T#5]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:32059
 IO_ReadThroughput:0.0
@@ -13766,7 +13766,7 @@ Sched_Runtime:3.044027057291667E-4
 Sched_Waittime:1.9028601302083334E-4
 Sched_CtxRate:74.81005260081824
 Heap_AllocRate:7458445.778311324
-threadName:opensearch[4sqG_AP][transport_client_boss][T#2]
+threadName:opensearch[4sqG_AP][transport_worker][T#2]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:196585
 IO_ReadThroughput:0.0
@@ -13785,7 +13785,7 @@ Sched_Runtime:6.982745094339623E-4
 Sched_Waittime:3.889433270440252E-4
 Sched_CtxRate:30.9760374050263
 Heap_AllocRate:6185786.135840752
-threadName:opensearch[4sqG_AP][[transport_server_worker.default]][T#8]
+threadName:opensearch[4sqG_AP][[transport_worker]][T#8]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:31842
 IO_ReadThroughput:0.0
@@ -13918,7 +13918,7 @@ Sched_Runtime:6.065697989623865E-4
 Sched_Waittime:2.8444952658884565E-4
 Sched_CtxRate:150.20455873758036
 Heap_AllocRate:3.9109914574372314E7
-threadName:opensearch[4sqG_AP][transport_client_boss][T#1]
+threadName:opensearch[4sqG_AP][transport_worker][T#1]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:195167
 IO_ReadThroughput:0.0
@@ -14051,7 +14051,7 @@ Sched_Runtime:5.097909090909091E-5
 Sched_Waittime:3.331027272727273E-5
 Sched_CtxRate:2.142996298460939
 Heap_AllocRate:618.5855756727018
-threadName:opensearch[4sqG_AP][[transport_server_worker.default]][T#4]
+threadName:opensearch[4sqG_AP][[transport_worker]][T#4]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:1946
 IO_ReadThroughput:0.0
@@ -19562,7 +19562,7 @@ Sched_Runtime:1.13758E-5
 Sched_Waittime:0.0019000086000000003
 Sched_CtxRate:0.9740892265731541
 Heap_AllocRate:0.0
-threadName:opensearch[4sqG_AP][transport_client_boss][T#7]
+threadName:opensearch[4sqG_AP][transport_worker][T#7]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:1
 IO_ReadThroughput:0.0
@@ -25033,7 +25033,7 @@ Sched_Runtime:3.0084414285714287E-4
 Sched_Waittime:3.991142857142858E-6
 Sched_CtxRate:1.3637249172024157
 Heap_AllocRate:83616.64665866346
-threadName:opensearch[4sqG_AP][transport_client_boss][T#8]
+threadName:opensearch[4sqG_AP][transport_worker][T#8]
 Thread_Blocked_Time:0.0
 Thread_Blocked_Event:626
 IO_ReadThroughput:0.0


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
#41 
#66 

**Describe the solution you are proposing**
- The transport thread names are now a regex containing the string `transport_worker`. 
We replace the older and now defunct thread names and `transport_client_boss` and `transport_server_worker` and their corresponding values for Operation dimension in PA metrics API
- The search and write/bulk thread names are currently being ignored and not being categorised as values in the Operation dimension. Added the same

**Testing Output**
`% curl "http://localhost:9600/_plugins/_performanceanalyzer/metrics?metrics=Thread_Blocked_Time&dim=Operation&agg=avg" `

`{"V72-8JqfRHKlMxUGO-HzBw": {"timestamp": 1630517885000, "data": {"fields":[{"name":"Operation","type":"VARCHAR"},{"name":"Thread_Blocked_Time","type":"DOUBLE"}],"records":[["GC",0.0],["flush",0.0],["generic",0.0],["management",0.0],["other",0.0],["refresh",0.0],["shardquery",0.0],["snapshot",0.0],["transportWorker",0.0],["search",0.0], ["write",0.0]]}}}% `

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
