### PR TITLE
Fix spotbugs failure by removing unused variable.

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/reader/ReaderMetricsProcessor.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/reader/ReaderMetricsProcessor.java
@@ -600,9 +600,6 @@ public class ReaderMetricsProcessor implements Runnable {
             on reader to avoid this.
         */
 
-        // Step 1 from above.
-        long start = System.currentTimeMillis();
-
         // Step 2 from above.
         long currWindowStartTime =
                 PerformanceAnalyzerMetrics.getTimeInterval(


### PR DESCRIPTION
Signed-off-by: Marc Handalian <handalm@amazon.com>

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
This PR fixes the build of main by fixing spotbugs to pass.

[This](https://github.com/opensearch-project/performance-analyzer-rca/commit/e03a8fb5504d8cda8a09da8b2248498b78795da3#diff-5c0956a1db407ce2ae60579e09c90a72a48845dbc91a5330ec3dd9394f19275c) commit removed the usage of this variable but left its declaration, causing spotbugs to fail.

**Describe the solution you are proposing**
Remove unused variable.  Without this change the following fails on main:

```
./gradlew build -x test
```

This is further causing problems because the performance-analyzer plugin repo always clones and builds main.

closes #46 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
