### PR TITLE
Add master not up writer metric 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -222,9 +222,6 @@ test {
         excludeTestsMatching 'org.opensearch.performanceanalyzer.rca.integTests.tests.consolidate_tuning.JvmFlipFlopITest'
     }
     enabled = true
-    retry {
-        maxRetries = 2
-    }
 }
 
 task rcaTest(type: Test) {

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/framework/metrics/WriterMetrics.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/framework/metrics/WriterMetrics.java
@@ -75,8 +75,11 @@ public enum WriterMetrics implements MeasurementSet {
             "namedCount",
             Collections.singletonList(Statistics.NAMED_COUNTERS)),
 
-    /** This metric indicates faiure in collecting MasterServiceEventMetrics */
+    /** This metric indicates failure in collecting MasterServiceEventMetrics */
     MASTER_METRICS_ERROR("MasterMetricsError"),
+
+    /** This metric indicates master is not up */
+    MASTER_NODE_NOT_UP("MasterNodeNotUp"),
 
     /** This metric indicates faiure in intercepting opensearch requests at transport channel */
     OPENSEARCH_REQUEST_INTERCEPTOR_ERROR("OpenSearchRequestInterceptorError"),

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/threadpool/QueueRejectionRca.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/threadpool/QueueRejectionRca.java
@@ -195,7 +195,8 @@ public class QueueRejectionRca extends Rca<ResourceFlowUnit<HotNodeSummary>> {
                         // If the RCA receives 3 empty flow units, re-set the 'hasMetric' value
                         hasRejection = false;
                         clearCounter = 0;
-                        LOG.error(
+                        // This is expected on master nodes.
+                        LOG.debug(
                                 "{} encountered {} empty flow units, re-setting the hasRejection value.",
                                 this.getClass().getSimpleName(),
                                 consecutivePeriodsToClear);


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

**Describe the solution you are proposing**
This change is a part of the refactoring stats collector change. Adding a writer metric that performance analyzer plugin will use for emitting metric denoting if the master node is up or not. 

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
