### PR TITLE
Use performance-analyzer main branch.

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -59,8 +59,8 @@ jobs:
     - name: Checkout Performance Analyzer
       uses: actions/checkout@v2
       with:
-        repository: dblock/performance-analyzer
-        ref: fix-snapshot-build
+        repository: opensearch-project/performance-analyzer
+        ref: main
         path: ./tmp/performance-analyzer
     - name: Build PA gradle using the new RCA jar
       working-directory: ./tmp/performance-analyzer


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

Now that https://github.com/opensearch-project/performance-analyzer/pull/53 has been merged, use the main branch thereof.

Together with #55, closes #40, closes #56.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
