### PR TITLE
AdmissionControl Split RCA

### DIFF
--- a/pa_config/rca.conf
+++ b/pa_config/rca.conf
@@ -71,33 +71,18 @@
         "heap-range": [
           {
             "lower-bound": 0,
-            "upper-bound": 75,
+            "upper-bound": 80,
             "threshold": 15.0
           },
           {
-            "lower-bound": 76,
-            "upper-bound": 80,
-            "threshold": 12.5
-          },
-          {
             "lower-bound": 81,
-            "upper-bound": 85,
+            "upper-bound": 90,
             "threshold": 10.0
           },
           {
-            "lower-bound": 86,
-            "upper-bound": 90,
-            "threshold": 7.5
-          },
-          {
             "lower-bound": 91,
-            "upper-bound": 95,
-            "threshold": 5.0
-          },
-          {
-            "lower-bound": 96,
             "upper-bound": 100,
-            "threshold": 2.5
+            "threshold": 5.0
           }
         ]
       }

--- a/src/main/java/org/opensearch/performanceanalyzer/decisionmaker/actions/AdmissionControlAction.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/decisionmaker/actions/AdmissionControlAction.java
@@ -107,6 +107,8 @@ public class AdmissionControlAction extends SuppressibleAction {
             impactVector.increasesPressure(ADMISSION_CONTROL);
         } else if (desiredValue < currentValue) {
             impactVector.decreasesPressure(ADMISSION_CONTROL);
+        } else {
+            impactVector.noImpact(ADMISSION_CONTROL);
         }
         return Collections.singletonMap(esNode, impactVector);
     }

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/configs/AdmissionControlRcaConfig.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/configs/AdmissionControlRcaConfig.java
@@ -48,14 +48,9 @@ import org.opensearch.performanceanalyzer.util.range.Range;
  *       "heap-range": [
  *         {
  *           "lower-bound": 0,
- *           "upper-bound": 75,
- *           "threshold": 15
- *         },
- *         {
- *           "lower-bound": 76,
  *           "upper-bound": 80,
- *           "threshold": 12.5
- *         }
+ *           "threshold": 15.0
+ *         },
  *         ...
  *       ]
  *     }

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/store/OpenSearchAnalysisGraph.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/store/OpenSearchAnalysisGraph.java
@@ -472,10 +472,13 @@ public class OpenSearchAnalysisGraph extends AnalysisGraph {
         admissionControlClusterRca.addTag(
                 RcaConsts.RcaTagConstants.TAG_LOCUS, RcaConsts.RcaTagConstants.LOCUS_MASTER_NODE);
         admissionControlClusterRca.addAllUpstreams(Collections.singletonList(admissionControlRca));
+        admissionControlClusterRca.addTag(
+                RcaConsts.RcaTagConstants.TAG_AGGREGATE_UPSTREAM,
+                RcaConsts.RcaTagConstants.LOCUS_DATA_NODE);
 
         AdmissionControlDecider admissionControlDecider =
                 new AdmissionControlDecider(
-                        EVALUATION_INTERVAL_SECONDS, 12, admissionControlClusterRca);
+                        EVALUATION_INTERVAL_SECONDS, RCA_PERIOD, admissionControlClusterRca);
         admissionControlDecider.addTag(
                 RcaConsts.RcaTagConstants.TAG_LOCUS, RcaConsts.RcaTagConstants.LOCUS_MASTER_NODE);
         admissionControlDecider.addAllUpstreams(

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/admissioncontrol/heap/AdmissionControlByHeap.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/admissioncontrol/heap/AdmissionControlByHeap.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.opensearch.performanceanalyzer.rca.store.rca.admissioncontrol.heap;
+
+
+import org.opensearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
+import org.opensearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
+import org.opensearch.performanceanalyzer.rca.framework.util.InstanceDetails;
+import org.opensearch.performanceanalyzer.rca.store.rca.admissioncontrol.model.HeapMetric;
+import org.opensearch.performanceanalyzer.util.range.RangeConfiguration;
+
+/** Interface that can be implemented to calculate ResourceFlowUnit for various heap size */
+public interface AdmissionControlByHeap {
+    void init(InstanceDetails instanceDetails, RangeConfiguration rangeConfiguration);
+
+    ResourceFlowUnit<HotNodeSummary> generateFlowUnits(HeapMetric heapMetric);
+}

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/admissioncontrol/heap/AdmissionControlByHeapFactory.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/admissioncontrol/heap/AdmissionControlByHeapFactory.java
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.opensearch.performanceanalyzer.rca.store.rca.admissioncontrol.heap;
+
+
+import java.util.HashMap;
+import java.util.Map;
+
+/** HeapRcaFactory returns HeapRca based on maxHeap in gigabytes */
+public class AdmissionControlByHeapFactory {
+
+    // Heap Size in Gigabytes
+    private static final int SMALL_HEAP_RCA_THRESHOLD = 4;
+    private static final int MEDIUM_HEAP_RCA_THRESHOLD = 32;
+
+    // Keys for rcaMap
+    private static final String SMALL_HEAP = "SMALL_HEAP";
+    private static final String MEDIUM_HEAP = "MEDIUM_HEAP";
+    private static final String LARGE_HEAP = "LARGE_HEAP";
+
+    private static final Map<String, AdmissionControlByHeap> rcaMap = new HashMap<>();
+
+    public static AdmissionControlByHeap getByMaxHeap(double maxHeap) {
+        if (maxHeap <= SMALL_HEAP_RCA_THRESHOLD) {
+            if (!rcaMap.containsKey(SMALL_HEAP))
+                rcaMap.put(SMALL_HEAP, new AdmissionControlBySmallHeap());
+            return rcaMap.get(SMALL_HEAP);
+        } else if (maxHeap <= MEDIUM_HEAP_RCA_THRESHOLD) {
+            if (!rcaMap.containsKey(MEDIUM_HEAP))
+                rcaMap.put(MEDIUM_HEAP, new AdmissionControlByMediumHeap());
+            return rcaMap.get(MEDIUM_HEAP);
+        } else {
+            if (!rcaMap.containsKey(LARGE_HEAP))
+                rcaMap.put(LARGE_HEAP, new AdmissionControlByLargeHeap());
+            return rcaMap.get(LARGE_HEAP);
+        }
+    }
+}

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/admissioncontrol/heap/AdmissionControlByLargeHeap.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/admissioncontrol/heap/AdmissionControlByLargeHeap.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.opensearch.performanceanalyzer.rca.store.rca.admissioncontrol.heap;
+
+import static org.opensearch.performanceanalyzer.rca.framework.api.Resources.State.HEALTHY;
+
+import org.opensearch.performanceanalyzer.rca.framework.api.contexts.ResourceContext;
+import org.opensearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
+import org.opensearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
+import org.opensearch.performanceanalyzer.rca.framework.util.InstanceDetails;
+import org.opensearch.performanceanalyzer.rca.store.rca.admissioncontrol.model.HeapMetric;
+import org.opensearch.performanceanalyzer.util.range.RangeConfiguration;
+
+/** AdmissionControl RCA for heap > 32gb */
+public class AdmissionControlByLargeHeap implements AdmissionControlByHeap {
+
+    private InstanceDetails instanceDetails;
+
+    @Override
+    public void init(InstanceDetails instanceDetails, RangeConfiguration rangeConfiguration) {
+        this.instanceDetails = instanceDetails;
+    }
+
+    @Override
+    public ResourceFlowUnit<HotNodeSummary> generateFlowUnits(HeapMetric heapMetric) {
+        HotNodeSummary nodeSummary =
+                new HotNodeSummary(
+                        instanceDetails.getInstanceId(), instanceDetails.getInstanceIp());
+        return new ResourceFlowUnit<>(
+                System.currentTimeMillis(),
+                new ResourceContext(HEALTHY),
+                nodeSummary,
+                !instanceDetails.getIsMaster());
+    }
+}

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/admissioncontrol/heap/AdmissionControlByMediumHeap.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/admissioncontrol/heap/AdmissionControlByMediumHeap.java
@@ -1,0 +1,120 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.opensearch.performanceanalyzer.rca.store.rca.admissioncontrol.heap;
+
+import static org.opensearch.performanceanalyzer.PerformanceAnalyzerApp.RCA_VERTICES_METRICS_AGGREGATOR;
+import static org.opensearch.performanceanalyzer.rca.framework.api.Resources.State.HEALTHY;
+import static org.opensearch.performanceanalyzer.rca.framework.api.Resources.State.UNHEALTHY;
+import static org.opensearch.performanceanalyzer.rca.framework.api.summaries.ResourceUtil.HEAP_MAX_SIZE;
+import static org.opensearch.performanceanalyzer.rca.framework.metrics.RcaVerticesMetrics.ADMISSION_CONTROL_RCA_TRIGGERED;
+
+import java.util.Objects;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.performanceanalyzer.rca.framework.api.contexts.ResourceContext;
+import org.opensearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
+import org.opensearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
+import org.opensearch.performanceanalyzer.rca.framework.api.summaries.HotResourceSummary;
+import org.opensearch.performanceanalyzer.rca.framework.util.InstanceDetails;
+import org.opensearch.performanceanalyzer.rca.store.rca.admissioncontrol.model.HeapMetric;
+import org.opensearch.performanceanalyzer.util.range.Range;
+import org.opensearch.performanceanalyzer.util.range.RangeConfiguration;
+
+/** AdmissionControl RCA for heap > 4gb and <= 32gb */
+public class AdmissionControlByMediumHeap implements AdmissionControlByHeap {
+
+    private static final Logger LOG = LogManager.getLogger(AdmissionControlByMediumHeap.class);
+    private double previousHeapPercent = 0;
+
+    private InstanceDetails instanceDetails;
+    private RangeConfiguration requestSizeHeapRange;
+
+    @Override
+    public void init(InstanceDetails instanceDetails, RangeConfiguration rangeConfiguration) {
+        this.instanceDetails = instanceDetails;
+        this.requestSizeHeapRange = rangeConfiguration;
+    }
+
+    @Override
+    public ResourceFlowUnit<HotNodeSummary> generateFlowUnits(HeapMetric heapMetric) {
+
+        long currentTimeMillis = System.currentTimeMillis();
+        double currentHeapPercent = heapMetric.getHeapPercent();
+
+        HotNodeSummary nodeSummary =
+                new HotNodeSummary(
+                        instanceDetails.getInstanceId(), instanceDetails.getInstanceIp());
+
+        // If we observe heap percent range change then we tune request-size controller threshold
+        // by marking resource as unhealthy and setting desired value as configured
+        if (requestSizeHeapRange.hasRangeChanged(previousHeapPercent, currentHeapPercent)) {
+
+            double currentThreshold = getThreshold(requestSizeHeapRange, currentHeapPercent);
+            if (currentThreshold == 0) {
+                // AdmissionControl rejects all requests if threshold is set to 0, thus ignoring
+                return new ResourceFlowUnit<>(
+                        currentTimeMillis,
+                        new ResourceContext(HEALTHY),
+                        nodeSummary,
+                        !instanceDetails.getIsMaster());
+            }
+
+            LOG.debug(
+                    "[AdmissionControl] PreviousHeapPercent={} CurrentHeapPercent={} CurrentDesiredThreshold={}",
+                    previousHeapPercent,
+                    currentHeapPercent,
+                    currentThreshold);
+
+            double previousThreshold = getThreshold(requestSizeHeapRange, previousHeapPercent);
+            previousHeapPercent = currentHeapPercent;
+
+            HotResourceSummary resourceSummary =
+                    new HotResourceSummary(HEAP_MAX_SIZE, currentThreshold, previousThreshold, 0);
+            nodeSummary.appendNestedSummary(resourceSummary);
+
+            RCA_VERTICES_METRICS_AGGREGATOR.updateStat(
+                    ADMISSION_CONTROL_RCA_TRIGGERED, instanceDetails.getInstanceId().toString(), 1);
+
+            return new ResourceFlowUnit<>(
+                    currentTimeMillis,
+                    new ResourceContext(UNHEALTHY),
+                    nodeSummary,
+                    !instanceDetails.getIsMaster());
+        }
+
+        return new ResourceFlowUnit<>(
+                currentTimeMillis,
+                new ResourceContext(HEALTHY),
+                nodeSummary,
+                !instanceDetails.getIsMaster());
+    }
+
+    private double getThreshold(RangeConfiguration heapRange, double heapPercent) {
+        Range range = heapRange.getRange(heapPercent);
+        return Objects.isNull(range) ? 0 : range.getThreshold();
+    }
+}

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/admissioncontrol/heap/AdmissionControlBySmallHeap.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/admissioncontrol/heap/AdmissionControlBySmallHeap.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.opensearch.performanceanalyzer.rca.store.rca.admissioncontrol.heap;
+
+import static org.opensearch.performanceanalyzer.rca.framework.api.Resources.State.HEALTHY;
+
+import org.opensearch.performanceanalyzer.rca.framework.api.contexts.ResourceContext;
+import org.opensearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
+import org.opensearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
+import org.opensearch.performanceanalyzer.rca.framework.util.InstanceDetails;
+import org.opensearch.performanceanalyzer.rca.store.rca.admissioncontrol.model.HeapMetric;
+import org.opensearch.performanceanalyzer.util.range.RangeConfiguration;
+
+/** AdmissionControl RCA for heap <= 4gb */
+public class AdmissionControlBySmallHeap implements AdmissionControlByHeap {
+
+    private InstanceDetails instanceDetails;
+
+    @Override
+    public void init(InstanceDetails instanceDetails, RangeConfiguration rangeConfiguration) {
+        this.instanceDetails = instanceDetails;
+    }
+
+    @Override
+    public ResourceFlowUnit<HotNodeSummary> generateFlowUnits(HeapMetric heapMetric) {
+        HotNodeSummary nodeSummary =
+                new HotNodeSummary(
+                        instanceDetails.getInstanceId(), instanceDetails.getInstanceIp());
+        return new ResourceFlowUnit<>(
+                System.currentTimeMillis(),
+                new ResourceContext(HEALTHY),
+                nodeSummary,
+                !instanceDetails.getIsMaster());
+    }
+}

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/admissioncontrol/model/HeapMetric.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/admissioncontrol/model/HeapMetric.java
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.opensearch.performanceanalyzer.rca.store.rca.admissioncontrol.model;
+
+/** Represents used heap and max heap in gigabytes */
+public class HeapMetric {
+    private final double usedHeap;
+    private final double maxHeap;
+
+    public HeapMetric(double usedHeap, double maxHeap) {
+        this.usedHeap = usedHeap;
+        this.maxHeap = maxHeap;
+    }
+
+    public double getUsedHeap() {
+        return usedHeap;
+    }
+
+    public double getMaxHeap() {
+        return maxHeap;
+    }
+
+    public double getHeapPercent() {
+        if (this.getMaxHeap() == 0) {
+            return 0;
+        }
+        return 100 * this.getUsedHeap() / this.getMaxHeap();
+    }
+
+    public boolean hasValues() {
+        return this.getUsedHeap() != 0 && this.getMaxHeap() != 0;
+    }
+
+    @Override
+    public String toString() {
+        return "HeapMetric{" + "usedHeap=" + usedHeap + ", maxHeap=" + maxHeap + '}';
+    }
+}

--- a/src/main/java/org/opensearch/performanceanalyzer/util/range/Range.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/util/range/Range.java
@@ -31,9 +31,9 @@ import java.util.Objects;
 
 public class Range {
 
-    private double lowerBound;
-    private double upperBound;
-    private double threshold;
+    private final double lowerBound;
+    private final double upperBound;
+    private final double threshold;
 
     public Range(double lowerBound, double upperBound, double threshold) {
         this.lowerBound = lowerBound;

--- a/src/main/java/org/opensearch/performanceanalyzer/util/range/RequestSizeHeapRangeConfiguration.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/util/range/RequestSizeHeapRangeConfiguration.java
@@ -36,17 +36,17 @@ public class RequestSizeHeapRangeConfiguration implements RangeConfiguration {
 
     /**
      * Default request-size controller threshold for lower and upper bound of heap percent Here, new
-     * Range(0, 75, 15.0) => for heap percent between 0% and 75% set threshold to 15%
+     * Range(0, 80, 15.0) => for heap percent between 0% and 80% set threshold to 15% Idea here is
+     * to incentivize with more buckets to request-size controller if more heap is available. As
+     * memory pressure increases we reduce buckets to further reduce number of acceptable incoming
+     * requests.
      */
     private final Collection<Range> DEFAULT_RANGE_CONFIGURATION =
             Collections.unmodifiableList(
                     Arrays.asList(
-                            new Range(0, 75, 15.0),
-                            new Range(76, 80, 12.5),
-                            new Range(81, 85, 10.0),
-                            new Range(86, 90, 7.5),
-                            new Range(91, 95, 5.0),
-                            new Range(96, 100, 2.5)));
+                            new Range(0, 80, 15.0),
+                            new Range(81, 90, 10.0),
+                            new Range(91, 100, 5.0)));
 
     private Collection<Range> rangeConfiguration;
 

--- a/src/test/java/org/opensearch/performanceanalyzer/reader/MetricsEmitterTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/reader/MetricsEmitterTests.java
@@ -356,7 +356,8 @@ public class MetricsEmitterTests extends AbstractReaderTests {
                 "search",
                 MetricsEmitter.categorizeThreadName("opensearch[I9AByra][search]", dimensions));
         assertEquals(
-                "write", MetricsEmitter.categorizeThreadName("opensearch[I9AByra][bulk]", dimensions));
+                "write",
+                MetricsEmitter.categorizeThreadName("opensearch[I9AByra][bulk]", dimensions));
         assertEquals("other", MetricsEmitter.categorizeThreadName("Top thread random", dimensions));
     }
 

--- a/src/test/resources/rca/rca.conf
+++ b/src/test/resources/rca/rca.conf
@@ -69,33 +69,18 @@
         "heap-range": [
           {
             "lower-bound": 0,
-            "upper-bound": 75,
+            "upper-bound": 80,
             "threshold": 15.0
           },
           {
-            "lower-bound": 76,
-            "upper-bound": 80,
-            "threshold": 12.5
-          },
-          {
             "lower-bound": 81,
-            "upper-bound": 85,
+            "upper-bound": 90,
             "threshold": 10.0
           },
           {
-            "lower-bound": 86,
-            "upper-bound": 90,
-            "threshold": 7.5
-          },
-          {
             "lower-bound": 91,
-            "upper-bound": 95,
-            "threshold": 5.0
-          },
-          {
-            "lower-bound": 96,
             "upper-bound": 100,
-            "threshold": 2.5
+            "threshold": 5.0
           }
         ]
       }


### PR DESCRIPTION
Signed-off-by: Mital Awachat <awachatm@amazon.com>

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
* Split admission control rca into SmallHeap / MediumHeap / LargeHeap rca.
* Reduce number of buckets for default configuration request-size controller heap-range to reduce too many auto-tunes for  small percentage of heap variation.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
