### PR TITLE
Remove emitting the entry key with the METRICS_WRITE_ERROR metric

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/metrics/PerformanceAnalyzerMetrics.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/metrics/PerformanceAnalyzerMetrics.java
@@ -140,7 +140,7 @@ public class PerformanceAnalyzerMetrics {
     private static void emitMetric(BlockingQueue<Event> q, Event entry) {
         if (!q.offer(entry)) {
             PerformanceAnalyzerApp.WRITER_METRICS_AGGREGATOR.updateStat(
-                    WriterMetrics.METRICS_WRITE_ERROR, entry.key, 1);
+                    WriterMetrics.METRICS_WRITE_ERROR, "", 1);
             LOG.debug("Could not enter metric {}", entry);
         }
     }

--- a/src/test/java/org/opensearch/performanceanalyzer/reader/MetricsEmitterTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/reader/MetricsEmitterTests.java
@@ -356,7 +356,8 @@ public class MetricsEmitterTests extends AbstractReaderTests {
                 "search",
                 MetricsEmitter.categorizeThreadName("opensearch[I9AByra][search]", dimensions));
         assertEquals(
-                "write", MetricsEmitter.categorizeThreadName("opensearch[I9AByra][bulk]", dimensions));
+                "write",
+                MetricsEmitter.categorizeThreadName("opensearch[I9AByra][bulk]", dimensions));
         assertEquals("other", MetricsEmitter.categorizeThreadName("Top thread random", dimensions));
     }
 


### PR DESCRIPTION
Signed-off-by: Sruti Parthiban <partsrut@amazon.com>

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
There is an increase in cardinality of metrics due to a recently added metric ```MetricsWriteError``` which always has unique dimension value for field Instance as it includes timestamp and the threadId. This value was emitted continuously due a known bug causing the pa.plugin.stats file to grow really large. This bug is currently fixed in ```1.1```

**Describe the solution you are proposing**
Alter to remove emitting the entry key with the ```METRICS_WRITE_ERROR``` metric. 

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
