### PR TITLE
Add log rotation and prevent noisy logs

### DIFF
--- a/pa_config/log4j2.xml
+++ b/pa_config/log4j2.xml
@@ -4,14 +4,34 @@
         <Console name="Console" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />
         </Console>
-        <File name="PerformanceAnalyzerLog" fileName="/tmp/PerformanceAnalyzer.log" immediateFlush="true" append="true">
+        <RollingFile name="PerformanceAnalyzerLog" fileName="/tmp/PerformanceAnalyzer.log" filePattern="/tmp/PerformanceAnalyzer.log.%d{yyyy-MM-dd}-%i.gz" immediateFlush="true" append="true">
             <PatternLayout pattern="%d{yyy-MM-dd HH:mm:ss.SSS} [PA:Reader] [%t] %-5level %logger{36} - %msg%n"/>
-        </File>
-        <File name="StatsLog" fileName="/tmp/performance_analyzer_agent_stats.log" immediateFlush="true" append="true">
-        </File>
+            <Policies>
+                <TimeBasedTriggeringPolicy interval="1" modulate="true"/>
+                <SizeBasedTriggeringPolicy size="128 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy>
+                <Delete basePath="/tmp">
+                    <IfFileName glob="PerformanceAnalyzer.log.*.gz" />
+                    <IfAccumulatedFileSize exceeds="2 GB" />
+                </Delete>
+            </DefaultRolloverStrategy>
+        </RollingFile>
+        <RollingFile name="StatsLog" fileName="/tmp/performance_analyzer_agent_stats.log" filePattern="/tmp/performance_analyzer_agent_stats.log.%d{yyyy-MM-dd}-%i.gz" immediateFlush="true" append="true">
+            <Policies>
+                <TimeBasedTriggeringPolicy interval="1" modulate="true"/>
+                <SizeBasedTriggeringPolicy size="128 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy>
+                <Delete basePath="/tmp">
+                    <IfFileName glob="performance_analyzer_agent_stats.log.*.gz" />
+                    <IfAccumulatedFileSize exceeds="2 GB" />
+                </Delete>
+            </DefaultRolloverStrategy>
+        </RollingFile>
     </Appenders>
     <Loggers>
-        <Logger name="stats_log" level="info" additivity="false">
+        <Logger name="stats_log" level="debug" additivity="false">
             <AppenderRef ref="StatsLog"/>
         </Logger>
         <Root level="error">

--- a/src/main/java/org/opensearch/performanceanalyzer/collectors/StatsCollector.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/collectors/StatsCollector.java
@@ -224,7 +224,9 @@ public class StatsCollector extends PerformanceAnalyzerMetricsCollector {
 
         addEntry("Counters", getCountersString(counters), builder);
         builder.append(LOG_ENTRY_END); // + LOG_LINE_BREAK);
-        STATS_LOGGER.info(builder.toString());
+        /* Setting this log level to debug (and not info) to avoid logging noisy plugin stats
+        logs to the console and opensearch.log file */
+        STATS_LOGGER.debug(builder.toString());
     }
 
     private static String getCountersString(Map<String, AtomicInteger> counters) {


### PR DESCRIPTION
Signed-off-by: Karishma Joseph <karisjos@amazon.com>

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
https://github.com/opensearch-project/performance-analyzer/issues/80
#84

**Describe the solution you are proposing**
Rotate PerformanceAnalyzer.log and performance_analyzer_agent_stats.log files to avoid disk issue. Set the log level to debug (and not info) for the stats logs to prevent excessive noisy logs being piped to the console and opensearch.log file.

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
