### PR TITLE
Removing deprecated InitialBootClassLoaderMetaspaceSize JVM command line flag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,6 @@ application {
                                  '-XX:CICompilerCount=1',
                                  '-XX:-TieredCompilation',
                                  '-XX:InitialCodeCacheSize=4096',
-                                 '-XX:InitialBootClassLoaderMetaspaceSize=30720',
                                  '-XX:MaxRAM=400m']
 }
 


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
The `InitialBootClassLoaderMetaspaceSize` JVM command line flag has been deprecated in JDK-15 [1] and removed in JDK-16 [2]. 

[1] https://bugs.openjdk.java.net/browse/JDK-8242426 
[2] https://bugs.openjdk.java.net/browse/JDK-8221173

Related to https://github.com/opensearch-project/opensearch-build/issues/1523

**Describe the solution you are proposing**
Drop `InitialBootClassLoaderMetaspaceSize` usage

**Describe alternatives you've considered**
Make the command line logic dependent on JVM version being used

**Additional context**
Closes https://github.com/opensearch-project/performance-analyzer-rca/issues/117

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
