### PR TITLE
Revert "Upgrade grpc-netty version to 1.42.2 (#115)"

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -49,7 +49,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: opensearch-project/performance-analyzer
-        ref: feature/netty
+        ref: 1.2
         path: ./tmp/performance-analyzer
     - name: Build PA gradle using the new RCA jar
       working-directory: ./tmp/performance-analyzer

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@
 
 buildscript {
     dependencies {
-        classpath group: 'com.google.guava', name: 'guava', version: '30.1-jre'
+        classpath group: 'com.google.guava', name: 'guava', version: '28.2-jre'
         classpath 'org.ajoberstar:gradle-git:0.2.3'
     }
 }
@@ -319,24 +319,16 @@ dependencies {
     compile 'org.bouncycastle:bcprov-jdk15on:1.68'
     compile 'org.bouncycastle:bcpkix-jdk15on:1.68'
     compile 'org.xerial:sqlite-jdbc:3.32.3.2'
-    compile 'com.google.guava:guava:30.1-jre'
-    compile 'com.google.code.gson:gson:2.8.6'
-    compile 'org.checkerframework:checker-qual:3.5.0'
+    compile 'com.google.guava:guava:28.2-jre'
     compile "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
     compile "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
     compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.1'
     compile group: 'org.apache.logging.log4j', name: 'log4j-core', version: '2.17.1'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.9'
     compile group: 'commons-io', name: 'commons-io', version: '2.7'
-    compile(group: 'com.google.errorprone', name: 'error_prone_annotations', version: '2.9.0') {
-        force = 'true'
-    }
-    compile ('com.google.protobuf:protobuf-java:3.19.3') {
-        force = 'true'
-    }
-    implementation 'io.grpc:grpc-netty-shaded:1.42.2'
-    implementation 'io.grpc:grpc-protobuf:1.42.2'
-    implementation 'io.grpc:grpc-stub:1.42.2'
+    implementation 'io.grpc:grpc-netty-shaded:1.28.0'
+    implementation 'io.grpc:grpc-protobuf:1.28.0'
+    implementation 'io.grpc:grpc-stub:1.28.0'
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
 
     // JDK9+ has to run powermock 2+. https://github.com/powermock/powermock/issues/888
@@ -357,12 +349,12 @@ dependencies {
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:3.19.3"
+        artifact = "com.google.protobuf:protoc:3.11.0"
     }
 
     plugins {
         grpc {
-            artifact = 'io.grpc:protoc-gen-grpc-java:1.42.2'
+            artifact = 'io.grpc:protoc-gen-grpc-java:1.28.0'
         }
 
     }

--- a/checkstyle/findbugs-exclude.xml
+++ b/checkstyle/findbugs-exclude.xml
@@ -90,12 +90,4 @@
             <Bug pattern="UCF_USELESS_CONTROL_FLOW"/>
         </Or>
     </Match>
-    <Match>
-        <Class name="org.opensearch.performanceanalyzer.rca.store.rca.cluster.BaseClusterRca"/>
-        <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"/>
-    </Match>
-    <Match>
-        <Class name="org.opensearch.performanceanalyzer.rca.store.rca.hotshard.HotShardClusterRca"/>
-        <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"/>
-    </Match>
 </FindBugsFilter>


### PR DESCRIPTION
This reverts commit eeafdf53db74197921c5c88f62efddac0a46e775.

Signed-off-by: sruti1312 <srutiparthiban@gmail.com>

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

**Describe the solution you are proposing**
The version upgrade has been merged to ```main``` and reverting this commit as 1.2.4 is released.

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
