### PR TITLE
Update Bouncycastle to 1.70

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -316,8 +316,8 @@ dependencies {
     def jacksonVersion = "2.11.4"
 
     compile 'org.jooq:jooq:3.10.8'
-    compile 'org.bouncycastle:bcprov-jdk15on:1.68'
-    compile 'org.bouncycastle:bcpkix-jdk15on:1.68'
+    compile 'org.bouncycastle:bcprov-jdk15on:1.70'
+    compile 'org.bouncycastle:bcpkix-jdk15on:1.70'
     compile 'org.xerial:sqlite-jdbc:3.32.3.2'
     compile 'com.google.guava:guava:28.2-jre'
     compile "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
The build of `performance-analyzer` fails with:

```
Execution failed for task ':compileJava'.
> Could not resolve all dependencies for configuration ':compileClasspath'.
   > Conflict(s) found for the following module(s):
       - org.bouncycastle:bcprov-jdk15on between versions 1.70 and 1.68
       - org.bouncycastle:bcpkix-jdk15on between versions 1.70 and 1.68
     Run with:
         --scan or
         :dependencyInsight --configuration compileClasspath --dependency org.bouncycastle:bcprov-jdk15on
     to get more insight on how to solve the conflict.
                                                                                                         
```

**Describe the solution you are proposing**
Updating Bouncycastle to 1.70 since it was updated in  `core` [1] and `performance-analyzer` [2]:
[1] https://github.com/opensearch-project/OpenSearch/blob/main/buildSrc/version.properties#L28
[2] https://github.com/opensearch-project/performance-analyzer/blob/main/build.gradle#L256

**Describe alternatives you've considered**
N/A

**Additional context**
N/A

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
