### PR TITLE
[BUG] Fixes grpc channel leak issue and vertex buffer issue on non ac…

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/PerformanceAnalyzerApp.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/PerformanceAnalyzerApp.java
@@ -149,16 +149,7 @@ public class PerformanceAnalyzerApp {
                     new GRPCConnectionManager(settings.getHttpsEnabled());
             final ClientServers clientServers = createClientServers(connectionManager, appContext);
 
-            // Adds a hook to shut down resources after PA process exits due to some reason.
-            Runtime.getRuntime()
-                    .addShutdownHook(
-                            new Thread(
-                                    () -> {
-                                        LOG.info(
-                                                "Trying to shutdown  performance analyzer gracefully");
-                                        shutDownGracefully(clientServers);
-                                    }));
-
+            addShutdownHook(clientServers);
             startErrorHandlingThread(THREAD_PROVIDER, exceptionQueue);
 
             startReaderThread(appContext, THREAD_PROVIDER);
@@ -399,6 +390,18 @@ public class PerformanceAnalyzerApp {
     @VisibleForTesting
     public static void setRcaController(RcaController rcaController) {
         PerformanceAnalyzerApp.rcaController = rcaController;
+    }
+
+
+    // Adds a hook to shut down resources after PA process exits due to some reason.
+    private static void addShutdownHook(ClientServers clientServers) {
+        Runtime.getRuntime()
+                .addShutdownHook(
+                        new Thread(
+                                () -> {
+                                    LOG.info("Trying to shutdown performance analyzer gracefully");
+                                    shutDownGracefully(clientServers);
+                                }));
     }
 
     /**

--- a/src/main/java/org/opensearch/performanceanalyzer/net/NetClient.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/net/NetClient.java
@@ -67,8 +67,18 @@ public class NetClient {
         return connectionManager;
     }
 
-    private ConcurrentMap<InstanceDetails.Id, AtomicReference<StreamObserver<FlowUnitMessage>>>
-            perHostOpenDataStreamMap = new ConcurrentHashMap<>();
+    private ConcurrentMap<
+                    InstanceDetails.Id,
+                    ConcurrentMap<String, AtomicReference<StreamObserver<FlowUnitMessage>>>>
+            perHostAndNodeOpenDataStreamMap = new ConcurrentHashMap<>();
+
+    // Visible for testing
+    protected ConcurrentMap<
+                    InstanceDetails.Id,
+                    ConcurrentMap<String, AtomicReference<StreamObserver<FlowUnitMessage>>>>
+            getPerHostAndNodeOpenDataStreamMap() {
+        return perHostAndNodeOpenDataStreamMap;
+    }
 
     /**
      * Sends a subscribe request to a remote host. If the subscribe request fails because the remote
@@ -114,7 +124,8 @@ public class NetClient {
         LOG.debug("Publishing {} data to {}", flowUnitMessage.getGraphNode(), remoteHost);
         try {
             final StreamObserver<FlowUnitMessage> stream =
-                    getDataStreamForHost(remoteHost, serverResponseStream);
+                    getDataStreamForHost(
+                            remoteHost, flowUnitMessage.getGraphNode(), serverResponseStream);
             stream.onNext(flowUnitMessage);
             PerformanceAnalyzerApp.RCA_GRAPH_METRICS_AGGREGATOR.updateStat(
                     RcaGraphMetrics.NET_BYTES_OUT,
@@ -141,33 +152,43 @@ public class NetClient {
     public void stop() {
         LOG.debug("Shutting down client streaming connections..");
         closeAllDataStreams();
+        this.connectionManager.shutdown();
     }
 
     public void flushStream(final InstanceDetails.Id remoteHost) {
         LOG.debug("removing data streams for {} as we are no publishing to it.", remoteHost);
-        perHostOpenDataStreamMap.remove(remoteHost);
+        perHostAndNodeOpenDataStreamMap.remove(remoteHost);
     }
 
     private void closeAllDataStreams() {
-        for (Map.Entry<InstanceDetails.Id, AtomicReference<StreamObserver<FlowUnitMessage>>> entry :
-                perHostOpenDataStreamMap.entrySet()) {
+        for (Map.Entry<
+                        InstanceDetails.Id,
+                        ConcurrentMap<String, AtomicReference<StreamObserver<FlowUnitMessage>>>>
+                entry : perHostAndNodeOpenDataStreamMap.entrySet()) {
             LOG.debug("Closing stream for host: {}", entry.getKey());
             // Sending an onCompleted should trigger the subscriber's node state manager
-            // and cause this host to be put under observation.f
-            entry.getValue().get().onCompleted();
-            perHostOpenDataStreamMap.remove(entry.getKey());
+            // and cause this host to be put under observation.
+            // Closes stream for each node for an instance.
+            for (Map.Entry<String, AtomicReference<StreamObserver<FlowUnitMessage>>>
+                    perInstanceEntry : entry.getValue().entrySet()) {
+                perInstanceEntry.getValue().get().onCompleted();
+            }
+            perHostAndNodeOpenDataStreamMap.remove(entry.getKey());
         }
     }
 
     private StreamObserver<FlowUnitMessage> getDataStreamForHost(
             final InstanceDetails remoteHost,
+            final String graphNode,
             final StreamObserver<PublishResponse> serverResponseStream) {
-        final AtomicReference<StreamObserver<FlowUnitMessage>> streamObserverAtomicReference =
-                perHostOpenDataStreamMap.get(remoteHost.getInstanceId());
-        if (streamObserverAtomicReference != null) {
-            return streamObserverAtomicReference.get();
+        final ConcurrentMap<String, AtomicReference<StreamObserver<FlowUnitMessage>>>
+                streamObserverAtomicReference =
+                        perHostAndNodeOpenDataStreamMap.get(remoteHost.getInstanceId());
+        if (streamObserverAtomicReference != null
+                && streamObserverAtomicReference.get(graphNode) != null) {
+            return streamObserverAtomicReference.get(graphNode).get();
         }
-        return addOrUpdateDataStreamForHost(remoteHost, serverResponseStream);
+        return addOrUpdateDataStreamForHost(remoteHost, graphNode, serverResponseStream);
     }
 
     /**
@@ -179,13 +200,24 @@ public class NetClient {
      */
     private synchronized StreamObserver<FlowUnitMessage> addOrUpdateDataStreamForHost(
             final InstanceDetails remoteHost,
+            final String graphNode,
             final StreamObserver<PublishResponse> serverResponseStream) {
         InterNodeRpcServiceGrpc.InterNodeRpcServiceStub stub =
                 connectionManager.getClientStubForHost(remoteHost);
         final StreamObserver<FlowUnitMessage> dataStream = stub.publish(serverResponseStream);
-        perHostOpenDataStreamMap.computeIfAbsent(
-                remoteHost.getInstanceId(), s -> new AtomicReference<>());
-        perHostOpenDataStreamMap.get(remoteHost.getInstanceId()).set(dataStream);
+        perHostAndNodeOpenDataStreamMap.computeIfAbsent(
+                remoteHost.getInstanceId(),
+                k ->
+                        new ConcurrentHashMap<
+                                String, AtomicReference<StreamObserver<FlowUnitMessage>>>() {
+                            {
+                                put(graphNode, new AtomicReference<>());
+                            }
+                        });
+        perHostAndNodeOpenDataStreamMap
+                .get(remoteHost.getInstanceId())
+                .computeIfAbsent(graphNode, k -> new AtomicReference<>())
+                .set(dataStream);
         return dataStream;
     }
 }

--- a/src/main/java/org/opensearch/performanceanalyzer/net/NetServer.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/net/NetServer.java
@@ -271,7 +271,9 @@ public class NetServer extends InterNodeRpcServiceGrpc.InterNodeRpcServiceImplBa
         if (server != null) {
             server.shutdown();
             try {
-                server.awaitTermination(1, TimeUnit.MINUTES);
+                if (!server.awaitTermination(1, TimeUnit.MINUTES)) {
+                    LOG.warn("Timed out while gracefully shutting down net server");
+                }
             } catch (InterruptedException e) {
                 server.shutdownNow();
                 Thread.currentThread().interrupt();

--- a/src/main/java/org/opensearch/performanceanalyzer/net/NetServer.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/net/NetServer.java
@@ -26,6 +26,7 @@
 
 package org.opensearch.performanceanalyzer.net;
 
+import static org.opensearch.performanceanalyzer.rca.framework.metrics.WriterMetrics.GRPC_SERVER_CLOSURE_ERROR;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.grpc.Server;
@@ -44,6 +45,7 @@ import javax.net.ssl.SSLException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.performanceanalyzer.CertificateUtils;
+import org.opensearch.performanceanalyzer.PerformanceAnalyzerApp;
 import org.opensearch.performanceanalyzer.grpc.FlowUnitMessage;
 import org.opensearch.performanceanalyzer.grpc.InterNodeRpcServiceGrpc;
 import org.opensearch.performanceanalyzer.grpc.MetricsRequest;
@@ -272,6 +274,7 @@ public class NetServer extends InterNodeRpcServiceGrpc.InterNodeRpcServiceImplBa
             server.shutdown();
             try {
                 if (!server.awaitTermination(1, TimeUnit.MINUTES)) {
+                    PerformanceAnalyzerApp.WRITER_METRICS_AGGREGATOR.updateStat(GRPC_SERVER_CLOSURE_ERROR, "", 1);
                     LOG.warn("Timed out while gracefully shutting down net server");
                 }
             } catch (InterruptedException e) {

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/RcaController.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/RcaController.java
@@ -282,7 +282,7 @@ public class RcaController {
         }
     }
 
-    private void stop() {
+    public void stop() {
         rcaScheduler.shutdown();
         rcaNetClient.stop();
         rcaNetServer.stop();

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/framework/metrics/WriterMetrics.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/framework/metrics/WriterMetrics.java
@@ -210,7 +210,18 @@ public enum WriterMetrics implements MeasurementSet {
 
     /** This metric indicates faiure in cleaning up the event log files */
     METRICS_REMOVE_FAILURE("MetricsRemoveFailure", "count", Arrays.asList(Statistics.COUNT)),
-    ;
+
+    /** This metric indicates that error occurred while closing grpc channels. */
+    GRPC_CHANNEL_CLOSURE_ERROR("GrpcChannelClosureError", "count", Arrays.asList(Statistics.COUNT)),
+
+    /** This metric indicates that error occurred while closing grpc server. */
+    GRPC_SERVER_CLOSURE_ERROR("GrpcServerClosureError", "count", Arrays.asList(Statistics.COUNT)),
+
+    /** This metric indicates that error occurred while closing metrics db. */
+    METRICS_DB_CLOSURE_ERROR("MetricsDbClosureError", "count", Arrays.asList(Statistics.COUNT)),
+
+    /** This metric indicates that error occurred while closing database connection. */
+    IN_MEMORY_DATABASE_CONN_CLOSURE_ERROR("InMemoryDatabaseConnClosureError", "count", Arrays.asList(Statistics.COUNT));
 
     /** What we want to appear as the metric name. */
     private String name;

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/net/ReceivedFlowUnitStore.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/net/ReceivedFlowUnitStore.java
@@ -95,6 +95,7 @@ public class ReceivedFlowUnitStore {
      * @return An immutable list containing the flow units received from the network for the vertex.
      */
     public ImmutableList<FlowUnitMessage> drainNode(final String graphNode) {
+        LOG.debug("Draining flow units for vertex: {}", graphNode);
         final List<FlowUnitMessage> tempList = new ArrayList<>();
         BlockingQueue<FlowUnitMessage> existing = flowUnitMap.get(graphNode);
         if (existing == null) {

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/net/handler/PublishRequestHandler.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/net/handler/PublishRequestHandler.java
@@ -74,12 +74,15 @@ public class PublishRequestHandler {
 
     public void terminateUpstreamConnections() {
         for (final StreamObserver<PublishResponse> responseStream : upstreamResponseStreamList) {
+            /* TODO: We need to check somehow to see if stream was already completed before calling onNext.
+            This is causing issues and causes RCA thread to crash in some cases. */
             responseStream.onNext(
                     PublishResponse.newBuilder()
                             .setDataStatus(PublishResponseStatus.NODE_SHUTDOWN)
                             .build());
             responseStream.onCompleted();
         }
+        upstreamResponseStreamList.clear();
     }
 
     private class SendDataClientStreamUpdateConsumer implements StreamObserver<FlowUnitMessage> {

--- a/src/main/java/org/opensearch/performanceanalyzer/reader/ReaderMetricsProcessor.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/reader/ReaderMetricsProcessor.java
@@ -228,16 +228,18 @@ public class ReaderMetricsProcessor implements Runnable {
 
     public void shutdown() {
         try {
-            conn.close();
+            if (!conn.isClosed()) {
+                conn.close();
+            }
         } catch (Exception e) {
-            LOG.error("Unable to close inmemory database connection.");
+            LOG.error("Unable to close inmemory database connection.", e);
         }
 
         for (MetricsDB db : metricsDBMap.values()) {
             try {
                 db.close();
             } catch (Exception e) {
-                LOG.error("Unable to close database - {}", db.getDBFilePath());
+                LOG.error("Unable to close database - " + db.getDBFilePath(), e);
             }
         }
     }

--- a/src/main/java/org/opensearch/performanceanalyzer/reader/ReaderMetricsProcessor.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/reader/ReaderMetricsProcessor.java
@@ -26,6 +26,8 @@
 
 package org.opensearch.performanceanalyzer.reader;
 
+import static org.opensearch.performanceanalyzer.rca.framework.metrics.WriterMetrics.IN_MEMORY_DATABASE_CONN_CLOSURE_ERROR;
+import static org.opensearch.performanceanalyzer.rca.framework.metrics.WriterMetrics.METRICS_DB_CLOSURE_ERROR;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
@@ -232,6 +234,7 @@ public class ReaderMetricsProcessor implements Runnable {
                 conn.close();
             }
         } catch (Exception e) {
+            PerformanceAnalyzerApp.WRITER_METRICS_AGGREGATOR.updateStat(IN_MEMORY_DATABASE_CONN_CLOSURE_ERROR, "", 1);
             LOG.error("Unable to close inmemory database connection.", e);
         }
 
@@ -239,6 +242,7 @@ public class ReaderMetricsProcessor implements Runnable {
             try {
                 db.close();
             } catch (Exception e) {
+                PerformanceAnalyzerApp.WRITER_METRICS_AGGREGATOR.updateStat(METRICS_DB_CLOSURE_ERROR, "", 1);
                 LOG.error("Unable to close database - " + db.getDBFilePath(), e);
             }
         }

--- a/src/test/java/org/opensearch/performanceanalyzer/net/NetClientTest.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/net/NetClientTest.java
@@ -1,0 +1,117 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.opensearch.performanceanalyzer.net;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import io.grpc.stub.StreamObserver;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.opensearch.performanceanalyzer.grpc.FlowUnitMessage;
+import org.opensearch.performanceanalyzer.grpc.InterNodeRpcServiceGrpc;
+import org.opensearch.performanceanalyzer.grpc.PublishResponse;
+import org.opensearch.performanceanalyzer.metrics.AllMetrics;
+import org.opensearch.performanceanalyzer.rca.framework.util.InstanceDetails;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@PowerMockIgnore({"org.apache.logging.log4j.*", "com.sun.org.apache.xerces.*"})
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({NetClient.class, InterNodeRpcServiceGrpc.InterNodeRpcServiceStub.class})
+public class NetClientTest {
+
+    private static final List<String> DUMMY_GRAPH_NODES =
+            Arrays.asList("dummyNode1", "dummyNode2", "dummyNode3");
+
+    @Mock private GRPCConnectionManager connectionManager;
+    @Mock private StreamObserver<PublishResponse> publishResponseStreamObserver;
+    @Mock private StreamObserver<FlowUnitMessage> streamObserver;
+    private InterNodeRpcServiceGrpc.InterNodeRpcServiceStub stub;
+    private NetClient netClient;
+
+    @Before
+    public void setup() {
+        initMocks(this);
+        this.stub =
+                PowerMockito.mock(
+                        InterNodeRpcServiceGrpc.InterNodeRpcServiceStub
+                                .class); // Mocking final class
+        this.netClient = new NetClient(connectionManager);
+    }
+
+    @Test
+    public void testPublishWithDifferentNode() {
+        InstanceDetails dummyRemoteHost = new InstanceDetails(AllMetrics.NodeRole.ELECTED_MASTER);
+
+        DUMMY_GRAPH_NODES.forEach(
+                node -> {
+                    FlowUnitMessage flowUnitMessage =
+                            FlowUnitMessage.newBuilder().setGraphNode(node).build();
+                    mockForPublish(dummyRemoteHost, flowUnitMessage);
+                    netClient.publish(
+                            dummyRemoteHost, flowUnitMessage, publishResponseStreamObserver);
+                });
+
+        verify(connectionManager, times(DUMMY_GRAPH_NODES.size()))
+                .getClientStubForHost(any(InstanceDetails.class));
+
+        Assert.assertNotNull(
+                netClient
+                        .getPerHostAndNodeOpenDataStreamMap()
+                        .get(dummyRemoteHost.getInstanceId()));
+        // Assert that data stream map contains all the expected graph nodes.
+        Assert.assertEquals(
+                DUMMY_GRAPH_NODES.size(),
+                netClient
+                        .getPerHostAndNodeOpenDataStreamMap()
+                        .get(dummyRemoteHost.getInstanceId())
+                        .size());
+        DUMMY_GRAPH_NODES.forEach(
+                expectedGraph -> {
+                    Assert.assertTrue(
+                            netClient
+                                    .getPerHostAndNodeOpenDataStreamMap()
+                                    .get(dummyRemoteHost.getInstanceId())
+                                    .containsKey(expectedGraph));
+                });
+    }
+
+    private void mockForPublish(InstanceDetails instanceDetails, FlowUnitMessage flowUnitMessage) {
+        when(connectionManager.getClientStubForHost(instanceDetails)).thenReturn(stub);
+        PowerMockito.when(stub.publish(publishResponseStreamObserver)).thenReturn(streamObserver);
+        doNothing().when(streamObserver).onNext(flowUnitMessage);
+    }
+}

--- a/src/test/java/org/opensearch/performanceanalyzer/net/NetClientTest.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/net/NetClientTest.java
@@ -27,7 +27,10 @@
 package org.opensearch.performanceanalyzer.net;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
 import io.grpc.stub.StreamObserver;


### PR DESCRIPTION
…tive master.

Signed-off-by: Sagar Upadhyaya <sagar.upadhyaya.121@gmail.com>

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
This attempts to solve below issues:
1) GRPC Channel leaks within PA/RCA. This happens as channels are never closed when PA or RCA goes down.
2) Data node continues to publish flow units to old active master when master switch happens. This old master doesn't sends unsubscribe message to data node for all vertices(does it only for one now) as all of them share a common grpc stream. 
3) Unnecessary channels are opened from data node to non active master and flow units are communicated which are never processed by non active master causing it's vertex queue to be completely filled. 

**Describe the solution you are proposing**
1) Gracefully shutdown all the channels which were opened when PA or RCA is stopped/restarted. Does this by adding shutdown hook at PA level and closing/terminating channels when RCA is disabled.
2) Keeping and storing(in a map) different streams for different vertices. Whenever master switch happens, old master successfully unsubscribes itself from data node for all vertices.
3) Solved by 2 and also terminating connections wherever necessary.

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Add any other context or screenshots about the feature request here.

### Testing(Manual)

**1.  Scenario where data node continues to push to old master node:**

 Tested this scenario by killing es on active master on a cluster with 3 dedicated master and 1 data node.
 **Without this patch:**
 - Logs on data node suggesting it was still publishing flow units on both old and new active master.

```
Publishing OldGenContendedRca data to <new_master_node_id>::<new_master_node_ip>::MASTER::9600
Publishing OldGenContendedRca data to <old_active_master_node_id>::<old_active_master_node_ip>::MASTER::9600
```
- Logs on data node suggesting it only received unsubscribe request for only one(as all RCA were sharing single stream due a bug) RCA from old master

```
Unsubscribing <old_active_master_node_id> from QueueRejectionRca updates
```
 - Logs on old master which suggests that it still receiving flow units from data node but unable to process it.
```
Dropped flow unit because per vertex queue is full
```

**With patch:**
- Verified via logs that data node was only publishing to active master.
- Verified via logs that old master was not receiving flow units from data node anymore.
- Verified via logs in data node that old master did send unsubscribe message for all RCA's.
```
Unsubscribing <old_active_master_node_id> from QueueRejectionRca updates
Unsubscribing <old_active_master_node_id> from AdmissionControlRca updates
Unsubscribing <old_active_master_node_id> from HotNodeRca updates
Unsubscribing <old_active_master_node_id> from OldGenContendedRca updates
......
```




### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
