### PR TITLE
Fixes RCA crash on active master (#131)

### DIFF
--- a/src/test/java/org/opensearch/performanceanalyzer/rca/net/handler/PublishRequestHandlerTest.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/rca/net/handler/PublishRequestHandlerTest.java
@@ -1,0 +1,134 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+/*
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package org.opensearch.performanceanalyzer.rca.net.handler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import io.grpc.stub.StreamObserver;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.opensearch.performanceanalyzer.grpc.FlowUnitMessage;
+import org.opensearch.performanceanalyzer.grpc.PublishResponse;
+import org.opensearch.performanceanalyzer.rca.net.NodeStateManager;
+import org.opensearch.performanceanalyzer.rca.net.ReceivedFlowUnitStore;
+import org.opensearch.performanceanalyzer.rca.net.tasks.FlowUnitRxTask;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@PowerMockIgnore({"org.apache.logging.log4j.*", "com.sun.org.apache.xerces.*"})
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({AtomicReference.class, PublishRequestHandler.class})
+public class PublishRequestHandlerTest {
+
+    private static final List<String> DUMMY_GRAPH_NODES =
+            Arrays.asList("dummyNode1", "dummyNode2", "dummyNode3");
+
+    @Mock private NodeStateManager nodeStateManager;
+    @Mock private ReceivedFlowUnitStore receivedFlowUnitStore;
+    private AtomicReference<ExecutorService> atomicReference;
+    @Mock private ExecutorService executorService;
+    @Mock private StreamObserver<PublishResponse> serviceResponse;
+    private PublishRequestHandler publishRequestHandler;
+
+    @Before
+    public void setup() {
+        initMocks(this);
+        atomicReference =
+                (AtomicReference<ExecutorService>) PowerMockito.mock(AtomicReference.class);
+        PowerMockito.when(atomicReference.get()).thenReturn(executorService);
+        doNothing().when(executorService).execute(any(FlowUnitRxTask.class));
+        this.publishRequestHandler =
+                new PublishRequestHandler(nodeStateManager, receivedFlowUnitStore, atomicReference);
+    }
+
+    @Test
+    public void testGetClientStreamWithSampleInputs() {
+        List<StreamObserver<FlowUnitMessage>> flowUnitList = getClientStreamTestData(2, 5);
+
+        DUMMY_GRAPH_NODES.forEach(
+                node -> {
+                    FlowUnitMessage flowUnitMessage =
+                            FlowUnitMessage.newBuilder().setGraphNode(node).build();
+                    flowUnitList.forEach(
+                            flowUnitMessageStreamObserver -> {
+                                flowUnitMessageStreamObserver.onNext(flowUnitMessage);
+                            });
+                });
+
+        verify(executorService, times(DUMMY_GRAPH_NODES.size() * flowUnitList.size()))
+                .execute(any(FlowUnitRxTask.class));
+    }
+
+    @Test
+    public void testTerminateUpstreamConnsWithFewResponseStreamCompleted() {
+        List<StreamObserver<FlowUnitMessage>> flowUnitList = getClientStreamTestData(3, 6);
+        AtomicInteger numberOfStreamCompleted = new AtomicInteger();
+        flowUnitList.forEach(
+                flowUnitMessageStreamObserver -> {
+                    if (new Random().nextBoolean()) {
+                        flowUnitMessageStreamObserver.onCompleted();
+                        numberOfStreamCompleted.getAndIncrement();
+                    }
+                });
+        // Verify that till now onNext on stream was invoked for this many times.
+        verify(serviceResponse, times(numberOfStreamCompleted.get()))
+                .onNext(any(PublishResponse.class));
+        publishRequestHandler.terminateUpstreamConnections();
+        // Verify that now onNext on stream should have been called for total number of response
+        // stream present.
+        verify(serviceResponse, times(flowUnitList.size())).onNext(any(PublishResponse.class));
+        Assert.assertTrue(publishRequestHandler.getDataClientStreamList().isEmpty());
+    }
+
+    private List<StreamObserver<FlowUnitMessage>> getClientStreamTestData(
+            int lowerBound, int upperBound) {
+        int randomNumber =
+                new Random().nextInt((upperBound - lowerBound + 1))
+                        + lowerBound; // [5, 10] Upper bound included.
+        List<StreamObserver<FlowUnitMessage>> flowUnitList = new ArrayList<>();
+        for (int iterator = 1; iterator <= randomNumber; iterator++) {
+            flowUnitList.add(publishRequestHandler.getClientStream(serviceResponse));
+        }
+        return flowUnitList;
+    }
+}


### PR DESCRIPTION
Signed-off-by: Sagar Upadhyaya <sagar.upadhyaya.121@gmail.com>

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
https://github.com/opensearch-project/performance-analyzer-rca/issues/131

**Describe the solution you are proposing**
- Keeps track of which streams were already completed by client via a flag "isCompleted". When RCA is disabled, publisher(active master) checks whether this response stream was already completed. If it was completed, it doesn't invoke onNext on response stream to convey it is shutting down.

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
