### PR TITLE
Remove PA-RCA files from OS home dir

### DIFF
--- a/pa_bin/performance-analyzer-agent
+++ b/pa_bin/performance-analyzer-agent
@@ -29,12 +29,12 @@ echo "Using JAVA_HOME: $JAVA_HOME"
 export JAVA_HOME=$JAVA_HOME
 
 if ! echo $* | grep -E '(^-d |-d$| -d |--daemonize$|--daemonize )' > /dev/null; then
-    export JAVA_OPTS=-Dopensearch.path.home=$OPENSEARCH_HOME\ -Dlog4j.configurationFile=$OPENSEARCH_HOME/performance-analyzer-rca/pa_config/log4j2.xml\ -XX:+ExitOnOutOfMemoryError
-    exec $OPENSEARCH_HOME/performance-analyzer-rca/bin/performance-analyzer-rca
+    export JAVA_OPTS=-Dopensearch.path.home=$OPENSEARCH_HOME\ -Dlog4j.configurationFile=$OPENSEARCH_HOME/plugins/opensearch-performance-analyzer/pa_config/log4j2.xml\ -XX:+ExitOnOutOfMemoryError
+    exec $OPENSEARCH_HOME/plugins/opensearch-performance-analyzer/rca_bin/performance-analyzer-rca
 else
     echo 'Starting deamon'
-    export JAVA_OPTS=-Dopensearch.path.home=$OPENSEARCH_HOME\ -Dlog4j.configurationFile=$OPENSEARCH_HOME/performance-analyzer-rca/pa_config/log4j2.xml\ -XX:+ExitOnOutOfMemoryError
-    exec $OPENSEARCH_HOME/performance-analyzer-rca/bin/performance-analyzer-rca &
+    export JAVA_OPTS=-Dopensearch.path.home=$OPENSEARCH_HOME\ -Dlog4j.configurationFile=$OPENSEARCH_HOME/plugins/opensearch-performance-analyzer/pa_config/log4j2.xml\ -XX:+ExitOnOutOfMemoryError
+    exec $OPENSEARCH_HOME/plugins/opensearch-performance-analyzer/rca_bin/performance-analyzer-rca &
 
     pid=$!
     PID_LOC=/tmp/performance-analyzer-agent

--- a/src/main/java/org/opensearch/performanceanalyzer/core/Util.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/core/Util.java
@@ -65,8 +65,6 @@ public class Util {
                     + File.separator
                     + "opensearch-performance-analyzer"
                     + File.separator;
-    public static final String READER_LOCATION =
-            OPENSEARCH_HOME + File.separator + "performance-analyzer-rca" + File.separator;
     public static final String DATA_DIR =
             OPENSEARCH_HOME + File.separator + "data" + File.separator;
 

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/framework/util/RcaConsts.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/framework/util/RcaConsts.java
@@ -43,7 +43,7 @@ public class RcaConsts {
     private static final String RCA_CONF_IDLE_MASTER_FILENAME = "rca_idle_master.conf";
     private static final String THRESHOLDS_DIR_NAME = "thresholds";
     public static final String CONFIG_DIR_PATH =
-            Paths.get(Util.READER_LOCATION, "pa_config").toString();
+            Paths.get(Util.PLUGIN_LOCATION, "pa_config").toString();
     public static final String RCA_CONF_PATH =
             Paths.get(CONFIG_DIR_PATH, RCA_CONF_FILENAME).toString();
     public static final String RCA_CONF_MASTER_PATH =


### PR DESCRIPTION
Signed-off-by: Karishma Joseph <karisjos@amazon.com>

[Merge only when PA is stable]

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
https://github.com/opensearch-project/performance-analyzer/issues/82

**Describe the solution you are proposing**
Remove the`<OS_HOME>/performance-analyzer-rca` folder from the OS home directory. This way there is only one location for PA plugin and PA-RCA process: `<OS_HOME>/plugins/opensearch-performance-analyzer`. 

Contents of `<OS_HOME>/performance-analyzer-rca` before:
```
bin  lib  pa_bin  pa_config
```


`pa_bin` and `pa_config` in `<OS_HOME>/performance-analyzer-rca` and `<OS_HOME>/plugins/opensearch-performance-analyzer` were exactly the same. Hence, no action need to be taken for these two folders.

Copy `bin` into `<OS_HOME>/plugins/opensearch-performance-analyzer` and rename as `rca_bin`.

Copy `lib` into `<OS_HOME>/plugins/opensearch-performance-analyzer` and rename as `rca_lib`. Remove all the common library files between `<OS_HOME>/plugins/opensearch-performance-analyzer` and `<OS_HOME>/plugins/opensearch-performance-analyzer/rca_lib` so as to reduce the memory footprint.


### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
