### PR TITLE
Exporting module to fix PA JDK 17 runtime issue

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/jvm/ThreadList.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/jvm/ThreadList.java
@@ -164,6 +164,9 @@ public class ThreadList {
 
     // Attach to pid and perform a thread dump
     private static void runAttachDump(String pid, String[] args) {
+        // Setting this property as runtime which is needed in JDK 17. This is called by plugin. Other option was
+        // to set as jvm args in the main app(opensearch) which doesn't feasible.
+        System.setProperty("--add-opens", "jdk.attach/sun.tools.attach=ALL-UNNAMED");
         VirtualMachine vm = null;
         try {
             vm = VirtualMachine.attach(pid);


### PR DESCRIPTION
Signed-off-by: Sagar Upadhyaya <sagar.upadhyaya.121@gmail.com>

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
While testing JDK 17 with OS 1.3.0 version earlier, we saw PA resulting into exception([here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/src/main/java/org/opensearch/performanceanalyzer/jvm/ThreadList.java#L185)) as JDK 17 had breaking changes where we couldn't type cast into jdk internal classes during runtime. To fix this, desired module is being added with open access for now.

**Describe the solution you are proposing**
Adding open access to desired module to allow to proceed with runtime access to jdk internal class. 

**Describe alternatives you've considered**
 - Adding "add-export" in build.gradle. But it doesn't work as it complains "exporting a package from system module jdk.attach is not allowed with --release". 
 - As this is accessed by plugin, other way would be to add it as jvm args during start of OS application. But would require changes in OS which doesn't feasible.

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
