### PR TITLE
Thread Metrics RCA.

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/metrics/AllMetrics.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/metrics/AllMetrics.java
@@ -1185,6 +1185,7 @@ public class AllMetrics {
         SHARD_ROLE(Constants.SHARD_ROLE_VALUE),
         SHARD_ID(Constants.SHARDID_VALUE),
         EXCEPTION(Constants.EXCEPTION_VALUE),
+        THREAD_NAME(Constants.THREAD_NAME),
         FAILED(Constants.FAILED_VALUE);
 
         private final String value;
@@ -1205,6 +1206,7 @@ public class AllMetrics {
             public static final String SHARD_ROLE_VALUE = "ShardRole";
             public static final String EXCEPTION_VALUE = "Exception";
             public static final String FAILED_VALUE = "Failed";
+            public static final String THREAD_NAME = "ThreadName";
         }
     }
 
@@ -1250,7 +1252,8 @@ public class AllMetrics {
         INDEX_NAME(CommonDimension.INDEX_NAME.toString()),
         OPERATION(CommonDimension.OPERATION.toString()),
         SHARD_ROLE(CommonDimension.SHARD_ROLE.toString()),
-        SHARD_ID(CommonDimension.SHARD_ID.toString());
+        SHARD_ID(CommonDimension.SHARD_ID.toString()),
+        THREAD_NAME(CommonDimension.THREAD_NAME.toString());
 
         private final String value;
 

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/framework/metrics/ReaderMetrics.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/framework/metrics/ReaderMetrics.java
@@ -135,6 +135,21 @@ public enum ReaderMetrics implements MeasurementSet {
                     Statistics.COUNT,
                     Statistics.SUM)),
 
+    /** Number of transport threads in BLOCKED state. */
+    BLOCKED_TRANSPORT_THREAD_COUNT("BlockedTransportThreadCount", "count", Statistics.MAX),
+
+    /** Number of transport threads in WAITING or TIMED-WAITING state. */
+    WAITED_TRANSPORT_THREAD_COUNT("WaitedTransportThreadCount", "count", Statistics.MAX),
+
+    /** Max amount of time a transport thread has been BLOCKED in the past 60 seconds. */
+    MAX_TRANSPORT_THREAD_BLOCKED_TIME("MaxTransportThreadBlockedTime", "seconds", Statistics.MAX),
+
+    /**
+     * Max amount of time a transport thread has been in WAITING or TIMED-WAITING state in the past
+     * 60 seconds.
+     */
+    MAX_TRANSPORT_THREAD_WAITED_TIME("MaxTransportThreadWaitedTime", "seconds", Statistics.MAX),
+
     /**
      * A blanket exception code for {@link
      * org.opensearch.performanceanalyzer.reader.ReaderMetricsProcessor} failures.

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/hot_node/ThreadAnalysis.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/hot_node/ThreadAnalysis.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.performanceanalyzer.rca.store.rca.hot_node;
+
+
+import java.util.function.Predicate;
+import org.opensearch.performanceanalyzer.rca.framework.metrics.ReaderMetrics;
+
+public class ThreadAnalysis {
+    private final ThreadMetricsSlidingWindow blockedTimeWindow;
+
+    private final ThreadMetricsSlidingWindow waitedTimeWindow;
+    private final Predicate<String> typeFilter;
+    private final ReaderMetrics blockedThreadCountMetric,
+            waitedThreadCountMetric,
+            maxBlockedTimeMetric,
+            maxWaitedTimeMetric;
+
+    public ThreadAnalysis(
+            Predicate<String> typeFilter,
+            ReaderMetrics blockedThreadCountMetric,
+            ReaderMetrics waitedThreadCount,
+            ReaderMetrics maxBlockedTime,
+            ReaderMetrics maxWaitedTimeMetric) {
+        this.typeFilter = typeFilter;
+        this.blockedThreadCountMetric = blockedThreadCountMetric;
+        this.waitedThreadCountMetric = waitedThreadCount;
+        this.maxBlockedTimeMetric = maxBlockedTime;
+        this.maxWaitedTimeMetric = maxWaitedTimeMetric;
+        blockedTimeWindow = new ThreadMetricsSlidingWindow();
+        waitedTimeWindow = new ThreadMetricsSlidingWindow();
+    }
+
+    public ThreadMetricsSlidingWindow getBlockedTimeWindow() {
+        return blockedTimeWindow;
+    }
+
+    public ThreadMetricsSlidingWindow getWaitedTimeWindow() {
+        return waitedTimeWindow;
+    }
+
+    public Predicate<String> getTypeFilter() {
+        return typeFilter;
+    }
+
+    public ReaderMetrics getBlockedThreadCountMetric() {
+        return blockedThreadCountMetric;
+    }
+
+    public ReaderMetrics getWaitedThreadCountMetric() {
+        return waitedThreadCountMetric;
+    }
+
+    public ReaderMetrics getMaxBlockedTimeMetric() {
+        return maxBlockedTimeMetric;
+    }
+
+    public ReaderMetrics getMaxWaitedTimeMetric() {
+        return maxWaitedTimeMetric;
+    }
+}

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/hot_node/ThreadMetric.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/hot_node/ThreadMetric.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.performanceanalyzer.rca.store.rca.hot_node;
+
+public class ThreadMetric {
+    private final String name;
+    private final double value;
+    private final long timeStamp;
+
+    private final String operation;
+
+    public ThreadMetric(String threadName, double val, long timeStamp, String operation) {
+        this.name = threadName;
+        this.value = val;
+        this.timeStamp = timeStamp;
+        this.operation = operation;
+    }
+
+    public String getOperation() {
+        return operation;
+    }
+
+    public long getTimeStamp() {
+        return timeStamp;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public double getValue() {
+        return value;
+    }
+}

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/hot_node/ThreadMetricsRca.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/hot_node/ThreadMetricsRca.java
@@ -1,0 +1,368 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.performanceanalyzer.rca.store.rca.hot_node;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.time.Clock;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jooq.Record;
+import org.jooq.Result;
+import org.opensearch.performanceanalyzer.PerformanceAnalyzerApp;
+import org.opensearch.performanceanalyzer.grpc.FlowUnitMessage;
+import org.opensearch.performanceanalyzer.metrics.AllMetrics;
+import org.opensearch.performanceanalyzer.metricsdb.MetricsDB;
+import org.opensearch.performanceanalyzer.rca.framework.api.Metric;
+import org.opensearch.performanceanalyzer.rca.framework.api.Rca;
+import org.opensearch.performanceanalyzer.rca.framework.api.flow_units.MetricFlowUnit;
+import org.opensearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
+import org.opensearch.performanceanalyzer.rca.framework.api.metrics.Thread_Blocked_Time;
+import org.opensearch.performanceanalyzer.rca.framework.api.metrics.Thread_Waited_Time;
+import org.opensearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
+import org.opensearch.performanceanalyzer.rca.framework.core.RcaConf;
+import org.opensearch.performanceanalyzer.rca.framework.metrics.ReaderMetrics;
+import org.opensearch.performanceanalyzer.rca.scheduler.FlowUnitOperationArgWrapper;
+
+import static org.opensearch.performanceanalyzer.rca.framework.metrics.ReaderMetrics.BLOCKED_TRANSPORT_THREAD_COUNT;
+import static org.opensearch.performanceanalyzer.rca.framework.metrics.ReaderMetrics.WAITED_TRANSPORT_THREAD_COUNT;
+import static org.opensearch.performanceanalyzer.rca.framework.metrics.ReaderMetrics.MAX_TRANSPORT_THREAD_BLOCKED_TIME;
+import static org.opensearch.performanceanalyzer.rca.framework.metrics.ReaderMetrics.MAX_TRANSPORT_THREAD_WAITED_TIME;
+
+/**
+ * Analyzes thread_blocked_time and thread_waited_time metrics for all threads and in specific
+ * transport threads and publishes the following data: 1. Number of threads which are blocked for
+ * more than 5 seconds in past minute. 2. Number of threads which are in waiting/timed-waiting state
+ * for more than 5 seconds in past minute. 3. Maximum value of thread_blocked_time for a single
+ * thread in the past minute. 4. Maximum value of thread_waited_time for a single thread in the past
+ * minute.
+ */
+public class ThreadMetricsRca extends Rca<ResourceFlowUnit<HotNodeSummary>> {
+
+    private static final Logger LOG = LogManager.getLogger(ThreadMetricsRca.class);
+    public static final double HIGH_BLOCKED_TIME_THRESHOLD_IN_SECONDS = 5d;
+    private final int rcaPeriod;
+    private final Thread_Blocked_Time threadBlockedTime;
+    private final Thread_Waited_Time threadWaitedTime;
+    private final Clock clock;
+    @VisibleForTesting final List<ThreadAnalysis> threadAnalyses;
+
+    public ThreadMetricsRca(
+            final Thread_Blocked_Time threadBlockedTime,
+            final Thread_Waited_Time threadWaitedTime,
+            final int rcaPeriodInSeconds) {
+        super(rcaPeriodInSeconds);
+        this.rcaPeriod = rcaPeriodInSeconds;
+        this.threadBlockedTime = threadBlockedTime;
+        this.threadWaitedTime = threadWaitedTime;
+        threadAnalyses = new ArrayList<>();
+        initThreadAnalyses();
+        this.clock = Clock.systemUTC();
+    }
+
+    private void initThreadAnalyses() {
+        // transport threads
+        threadAnalyses.add(
+                new ThreadAnalysis(
+                        s -> s.contains("transport"),
+                        BLOCKED_TRANSPORT_THREAD_COUNT,
+                        WAITED_TRANSPORT_THREAD_COUNT,
+                        MAX_TRANSPORT_THREAD_BLOCKED_TIME,
+                        MAX_TRANSPORT_THREAD_WAITED_TIME));
+    }
+
+    @Override
+    public void generateFlowUnitListFromWire(FlowUnitOperationArgWrapper args) {
+        final List<FlowUnitMessage> flowUnitMessages =
+                args.getWireHopper().readFromWire(args.getNode());
+        final List<ResourceFlowUnit<HotNodeSummary>> flowUnitList = new ArrayList<>();
+        LOG.debug("rca: Executing fromWire: {}", this.getClass().getSimpleName());
+        for (FlowUnitMessage flowUnitMessage : flowUnitMessages) {
+            flowUnitList.add(ResourceFlowUnit.buildFlowUnitFromWrapper(flowUnitMessage));
+        }
+        setFlowUnits(flowUnitList);
+    }
+
+    @Override
+    public void readRcaConf(RcaConf conf) {}
+
+    @Override
+    public ResourceFlowUnit<HotNodeSummary> operate() {
+        try {
+            long currentTimeMillis = this.clock.millis();
+            LOG.debug("ThreadMetricsRca run at {}", currentTimeMillis);
+            collateThreadMetricData(currentTimeMillis);
+            publishStats();
+
+        } catch (Exception e) {
+            LOG.error("ThreadMetricsRca.operate() Failed", e);
+        }
+        return new ResourceFlowUnit<>(clock.millis());
+    }
+
+    private void publishStats() {
+        threadAnalyses.forEach(
+                analysis -> {
+                    PerformanceAnalyzerApp.READER_METRICS_AGGREGATOR.updateStat(
+                            analysis.getBlockedThreadCountMetric(),
+                            "",
+                            analysis.getBlockedTimeWindow()
+                                    .getCountExceedingThreshold(
+                                            HIGH_BLOCKED_TIME_THRESHOLD_IN_SECONDS));
+
+                    PerformanceAnalyzerApp.READER_METRICS_AGGREGATOR.updateStat(
+                            analysis.getMaxBlockedTimeMetric(),
+                            "",
+                            analysis.getBlockedTimeWindow().getMaxSum());
+
+                    PerformanceAnalyzerApp.READER_METRICS_AGGREGATOR.updateStat(
+                            analysis.getWaitedThreadCountMetric(),
+                            "",
+                            analysis.getWaitedTimeWindow()
+                                    .getCountExceedingThreshold(
+                                            HIGH_BLOCKED_TIME_THRESHOLD_IN_SECONDS));
+
+                    PerformanceAnalyzerApp.READER_METRICS_AGGREGATOR.updateStat(
+                            analysis.getMaxWaitedTimeMetric(),
+                            "",
+                            analysis.getWaitedTimeWindow().getMaxSum());
+                });
+    }
+
+    private void collateThreadMetricData(long currentTimeMillis) {
+        collateThreadMetricData(
+                currentTimeMillis, threadBlockedTime, ThreadAnalysis::getBlockedTimeWindow);
+        collateThreadMetricData(
+                currentTimeMillis, threadWaitedTime, ThreadAnalysis::getWaitedTimeWindow);
+    }
+
+    private void collateThreadMetricData(
+            long currentTimeMillis,
+            Metric metric,
+            Function<ThreadAnalysis, ThreadMetricsSlidingWindow> slidingWindowFunction) {
+        ArrayList<ThreadMetric> threadList = new ArrayList<>();
+        for (MetricFlowUnit flowUnit : metric.getFlowUnits()) {
+            if (flowUnit.isEmpty()) {
+                continue;
+            }
+            final Result<Record> result = flowUnit.getData();
+            if (result == null) {
+                continue;
+            }
+            for (Record record : result) {
+                Object nameObj = record.get(AllMetrics.CommonDimension.THREAD_NAME.toString());
+                Object operationObj = record.get(AllMetrics.CommonDimension.OPERATION.toString());
+                Object valObj = record.get(MetricsDB.AVG);
+                if (nameObj == null || operationObj == null || valObj == null) {
+                    continue;
+                }
+                try {
+                    String operation = operationObj.toString();
+                    String threadName = nameObj.toString();
+                    double val = Double.parseDouble(valObj.toString());
+                    if (val > 0) {
+                        ThreadMetric tm =
+                                new ThreadMetric(threadName, val, currentTimeMillis, operation);
+                        threadList.add(tm);
+                    }
+                } catch (Exception e) {
+                    LOG.error("ThreadMetricsRca.operate() Failed to parse data for record "
+                            + record.formatJSON(), e);
+                    break;
+                }
+            }
+        }
+        threadAnalyses.forEach(
+                analysis -> {
+                    ThreadMetricsSlidingWindow slidingWindow =
+                            slidingWindowFunction.apply(analysis);
+                    slidingWindow.next(
+                            currentTimeMillis,
+                            threadList.stream()
+                                    .filter(tm -> analysis.getTypeFilter().test(tm.operation))
+                                    .collect(Collectors.toList()));
+                });
+    }
+
+    public static class ThreadMetricsSlidingWindow {
+
+        private final Map<String, Deque<ThreadMetric>> metricsByThreadName;
+        private final Map<String, Double> metricSumMap;
+        private static final long SLIDING_WINDOW_SIZE_IN_SECONDS = 60;
+
+        public ThreadMetricsSlidingWindow() {
+            metricsByThreadName = new HashMap<>();
+            metricSumMap = new HashMap<>();
+        }
+
+        /** insert data into the sliding window */
+        public void next(long timestamp, List<ThreadMetric> threadMetricList) {
+            Set<String> newThreadNames = new HashSet<>();
+            for (ThreadMetric tm : threadMetricList) {
+                Deque<ThreadMetric> windowDeque;
+                if (metricsByThreadName.containsKey(tm.getName())) {
+                    windowDeque = metricsByThreadName.get(tm.getName());
+                    pruneExpiredEntries(tm.getTimeStamp(), windowDeque);
+                } else {
+                    windowDeque = new LinkedList<>();
+                    metricsByThreadName.put(tm.name, windowDeque);
+                }
+                windowDeque.addFirst(tm);
+                addValue(tm);
+                newThreadNames.add(tm.name);
+            }
+
+            for (Map.Entry<String, Deque<ThreadMetric>> entry : metricsByThreadName.entrySet()) {
+                if (newThreadNames.contains(entry.getKey())) {
+                    continue;
+                }
+                pruneExpiredEntries(timestamp, entry.getValue());
+            }
+            metricsByThreadName.entrySet().removeIf(e -> e.getValue().size() == 0);
+        }
+
+        private void pruneExpiredEntries(long endTimeStamp, Deque<ThreadMetric> windowDeque) {
+            while (!windowDeque.isEmpty()
+                    && TimeUnit.MILLISECONDS.toSeconds(
+                                    endTimeStamp - windowDeque.peekLast().getTimeStamp())
+                            > SLIDING_WINDOW_SIZE_IN_SECONDS) {
+                // remove from window
+                ThreadMetric prunedData = windowDeque.pollLast();
+                // update blocked time sum for thread in new window
+                if (prunedData != null) {
+                    removeValue(prunedData);
+                }
+            }
+        }
+
+        private void removeValue(ThreadMetric prunedData) {
+            updateValue(prunedData, false);
+        }
+
+        private void addValue(ThreadMetric prunedData) {
+            updateValue(prunedData, true);
+        }
+
+        private void updateValue(ThreadMetric tm, boolean add) {
+            String threadName = tm.name;
+            if (metricSumMap.containsKey(threadName)) {
+                double sign = add ? 1d : -1d;
+                double newVal = metricSumMap.get(threadName) + sign * tm.getValue();
+                if (newVal == 0) {
+                    metricSumMap.remove(threadName);
+                } else {
+                    metricSumMap.put(threadName, newVal);
+                }
+            } else if (add) {
+                metricSumMap.put(threadName, tm.getValue());
+            }
+        }
+
+        public int getCountExceedingThreshold(double threshold) {
+            return (int) metricSumMap.values().stream().filter(val -> val > threshold).count();
+        }
+
+        public double getMaxSum() {
+            return metricSumMap.size() > 0 ? Collections.max(metricSumMap.values()) : 0d;
+        }
+    }
+
+    public static class ThreadMetric {
+        private final String name;
+        private final double value;
+        private final long timeStamp;
+
+        private final String operation;
+
+        public ThreadMetric(String threadName, double val, long timeStamp, String operation) {
+            this.name = threadName;
+            this.value = val;
+            this.timeStamp = timeStamp;
+            this.operation = operation;
+        }
+
+        public String getOperation() {
+            return operation;
+        }
+
+        public long getTimeStamp() {
+            return timeStamp;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public double getValue() {
+            return value;
+        }
+    }
+
+    public static class ThreadAnalysis {
+        public ThreadMetricsSlidingWindow getBlockedTimeWindow() {
+            return blockedTimeWindow;
+        }
+
+        public ThreadMetricsSlidingWindow getWaitedTimeWindow() {
+            return waitedTimeWindow;
+        }
+
+        public Predicate<String> getTypeFilter() {
+            return typeFilter;
+        }
+
+        public ReaderMetrics getBlockedThreadCountMetric() {
+            return blockedThreadCountMetric;
+        }
+
+        public ReaderMetrics getWaitedThreadCountMetric() {
+            return waitedThreadCountMetric;
+        }
+
+        public ReaderMetrics getMaxBlockedTimeMetric() {
+            return maxBlockedTimeMetric;
+        }
+
+        public ReaderMetrics getMaxWaitedTimeMetric() {
+            return maxWaitedTimeMetric;
+        }
+
+        private final ThreadMetricsSlidingWindow blockedTimeWindow;
+        private final ThreadMetricsSlidingWindow waitedTimeWindow;
+        private final Predicate<String> typeFilter;
+        private final ReaderMetrics blockedThreadCountMetric,
+                waitedThreadCountMetric,
+                maxBlockedTimeMetric,
+                maxWaitedTimeMetric;
+
+        public ThreadAnalysis(
+                Predicate<String> typeFilter,
+                ReaderMetrics blockedThreadCountMetric,
+                ReaderMetrics waitedThreadCount,
+                ReaderMetrics maxBlockedTime,
+                ReaderMetrics maxWaitedTimeMetric) {
+            this.typeFilter = typeFilter;
+            this.blockedThreadCountMetric = blockedThreadCountMetric;
+            this.waitedThreadCountMetric = waitedThreadCount;
+            this.maxBlockedTimeMetric = maxBlockedTime;
+            this.maxWaitedTimeMetric = maxWaitedTimeMetric;
+            blockedTimeWindow = new ThreadMetricsSlidingWindow();
+            waitedTimeWindow = new ThreadMetricsSlidingWindow();
+        }
+    }
+}

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/hot_node/ThreadMetricsSlidingWindow.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/store/rca/hot_node/ThreadMetricsSlidingWindow.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.performanceanalyzer.rca.store.rca.hot_node;
+
+
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+public class ThreadMetricsSlidingWindow {
+
+    private final Map<String, Deque<ThreadMetric>> metricsByThreadName;
+    private final Map<String, Double> metricSumMap;
+    private static final long SLIDING_WINDOW_SIZE_IN_SECONDS = 60;
+
+    public ThreadMetricsSlidingWindow() {
+        metricsByThreadName = new HashMap<>();
+        metricSumMap = new HashMap<>();
+    }
+
+    /** insert data into the sliding window */
+    public void next(long timestamp, List<ThreadMetric> threadMetricList) {
+        Set<String> newThreadNames = new HashSet<>();
+        for (ThreadMetric tm : threadMetricList) {
+            Deque<ThreadMetric> windowDeque;
+            if (metricsByThreadName.containsKey(tm.getName())) {
+                windowDeque = metricsByThreadName.get(tm.getName());
+                pruneExpiredEntries(tm.getTimeStamp(), windowDeque);
+            } else {
+                windowDeque = new LinkedList<>();
+                metricsByThreadName.put(tm.getName(), windowDeque);
+            }
+            windowDeque.addFirst(tm);
+            addValue(tm);
+            newThreadNames.add(tm.getName());
+        }
+
+        for (Map.Entry<String, Deque<ThreadMetric>> entry : metricsByThreadName.entrySet()) {
+            if (newThreadNames.contains(entry.getKey())) {
+                continue;
+            }
+            pruneExpiredEntries(timestamp, entry.getValue());
+        }
+        metricsByThreadName.entrySet().removeIf(e -> e.getValue().size() == 0);
+    }
+
+    private void pruneExpiredEntries(long endTimeStamp, Deque<ThreadMetric> windowDeque) {
+        while (!windowDeque.isEmpty()
+                && TimeUnit.MILLISECONDS.toSeconds(
+                                endTimeStamp - windowDeque.peekLast().getTimeStamp())
+                        > SLIDING_WINDOW_SIZE_IN_SECONDS) {
+            // remove from window
+            ThreadMetric prunedData = windowDeque.pollLast();
+            // update blocked time sum for thread in new window
+            if (prunedData != null) {
+                removeValue(prunedData);
+            }
+        }
+    }
+
+    private void removeValue(ThreadMetric prunedData) {
+        updateValue(prunedData, false);
+    }
+
+    private void addValue(ThreadMetric prunedData) {
+        updateValue(prunedData, true);
+    }
+
+    private void updateValue(ThreadMetric tm, boolean add) {
+        String threadName = tm.getName();
+        if (metricSumMap.containsKey(threadName)) {
+            double sign = add ? 1d : -1d;
+            double newVal = metricSumMap.get(threadName) + sign * tm.getValue();
+            if (newVal == 0) {
+                metricSumMap.remove(threadName);
+            } else {
+                metricSumMap.put(threadName, newVal);
+            }
+        } else if (add) {
+            metricSumMap.put(threadName, tm.getValue());
+        }
+    }
+
+    public int getCountExceedingThreshold(double threshold) {
+        return (int) metricSumMap.values().stream().filter(val -> val > threshold).count();
+    }
+
+    public double getMaxSum() {
+        return metricSumMap.size() > 0 ? Collections.max(metricSumMap.values()) : 0d;
+    }
+}

--- a/src/test/java/org/opensearch/performanceanalyzer/rca/store/rca/hot_node/ThreadMetricsRcaTest.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/rca/store/rca/hot_node/ThreadMetricsRcaTest.java
@@ -72,7 +72,7 @@ public class ThreadMetricsRcaTest {
                 mockThreadBlockedTime, threadBlockedTimeTableColumns, "10", "transport");
         setupMockThreadMetric(mockThreadWaitedTime, threadWaitedTimeTableColumns, "0", "transport");
         ResourceFlowUnit<HotNodeSummary> rfu = rca.operate();
-        assertTrue(rfu.isEmpty());
+        assertTrue(rfu.getResourceContext().isHealthy());
         assertEquals(rca.threadAnalyses.size(), 1);
         assertEquals(
                 rca.threadAnalyses.get(0).getBlockedTimeWindow().getCountExceedingThreshold(5), 1);
@@ -83,7 +83,7 @@ public class ThreadMetricsRcaTest {
         setupMockThreadMetric(mockThreadBlockedTime, threadBlockedTimeTableColumns, "10", "search");
         setupMockThreadMetric(mockThreadWaitedTime, threadWaitedTimeTableColumns, "0", "search");
         ResourceFlowUnit<HotNodeSummary> rfu = rca.operate();
-        assertTrue(rfu.isEmpty());
+        assertTrue(rfu.getResourceContext().isHealthy());
         assertEquals(rca.threadAnalyses.size(), 1);
         assertEquals(
                 rca.threadAnalyses.get(0).getBlockedTimeWindow().getCountExceedingThreshold(5), 0);

--- a/src/test/java/org/opensearch/performanceanalyzer/rca/store/rca/hot_node/ThreadMetricsRcaTest.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/rca/store/rca/hot_node/ThreadMetricsRcaTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.performanceanalyzer.rca.store.rca.hot_node;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.opensearch.performanceanalyzer.metrics.AllMetrics.CommonDimension.Constants.THREAD_NAME;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.opensearch.performanceanalyzer.metricsdb.MetricsDB;
+import org.opensearch.performanceanalyzer.rca.framework.api.Metric;
+import org.opensearch.performanceanalyzer.rca.framework.api.flow_units.MetricFlowUnit;
+import org.opensearch.performanceanalyzer.rca.framework.api.flow_units.ResourceFlowUnit;
+import org.opensearch.performanceanalyzer.rca.framework.api.metrics.MetricTestHelper;
+import org.opensearch.performanceanalyzer.rca.framework.api.metrics.Thread_Blocked_Time;
+import org.opensearch.performanceanalyzer.rca.framework.api.metrics.Thread_Waited_Time;
+import org.opensearch.performanceanalyzer.rca.framework.api.summaries.HotNodeSummary;
+import org.opensearch.performanceanalyzer.reader.ShardRequestMetricsSnapshot;
+
+public class ThreadMetricsRcaTest {
+
+    @Mock private Thread_Blocked_Time mockThreadBlockedTime;
+    @Mock private Thread_Waited_Time mockThreadWaitedTime;
+
+    private static final int PERIOD = 5;
+    private ThreadMetricsRca rca;
+    private MetricTestHelper metricTestHelper;
+    private final List<String> threadBlockedTimeTableColumns =
+            Arrays.asList(
+                    ShardRequestMetricsSnapshot.Fields.SHARD_ID.toString(),
+                    ShardRequestMetricsSnapshot.Fields.INDEX_NAME.toString(),
+                    ShardRequestMetricsSnapshot.Fields.OPERATION.toString(),
+                    ShardRequestMetricsSnapshot.Fields.SHARD_ROLE.toString(),
+                    THREAD_NAME,
+                    MetricsDB.SUM,
+                    MetricsDB.AVG,
+                    MetricsDB.MIN,
+                    MetricsDB.MAX);
+
+    private final List<String> threadWaitedTimeTableColumns =
+            Arrays.asList(
+                    ShardRequestMetricsSnapshot.Fields.SHARD_ID.toString(),
+                    ShardRequestMetricsSnapshot.Fields.INDEX_NAME.toString(),
+                    ShardRequestMetricsSnapshot.Fields.OPERATION.toString(),
+                    ShardRequestMetricsSnapshot.Fields.SHARD_ROLE.toString(),
+                    THREAD_NAME,
+                    MetricsDB.SUM,
+                    MetricsDB.AVG,
+                    MetricsDB.MIN,
+                    MetricsDB.MAX);
+
+    @Before
+    public void setup() throws Exception {
+        initMocks(this);
+        this.metricTestHelper = new MetricTestHelper(PERIOD);
+        this.rca = new ThreadMetricsRca(mockThreadBlockedTime, mockThreadWaitedTime, PERIOD);
+    }
+
+    @Test
+    public void testOperateWithTransportThread() {
+        setupMockThreadMetric(
+                mockThreadBlockedTime, threadBlockedTimeTableColumns, "10", "transport");
+        setupMockThreadMetric(mockThreadWaitedTime, threadWaitedTimeTableColumns, "0", "transport");
+        ResourceFlowUnit<HotNodeSummary> rfu = rca.operate();
+        assertTrue(rfu.isEmpty());
+        assertEquals(rca.threadAnalyses.size(), 1);
+        assertEquals(
+                rca.threadAnalyses.get(0).getBlockedTimeWindow().getCountExceedingThreshold(5), 1);
+    }
+
+    @Test
+    public void testOperateWithNonTransportThread() {
+        setupMockThreadMetric(mockThreadBlockedTime, threadBlockedTimeTableColumns, "10", "search");
+        setupMockThreadMetric(mockThreadWaitedTime, threadWaitedTimeTableColumns, "0", "search");
+        ResourceFlowUnit<HotNodeSummary> rfu = rca.operate();
+        assertTrue(rfu.isEmpty());
+        assertEquals(rca.threadAnalyses.size(), 1);
+        assertEquals(
+                rca.threadAnalyses.get(0).getBlockedTimeWindow().getCountExceedingThreshold(5), 0);
+    }
+
+    private void setupMockThreadMetric(
+            Metric metric, List<String> columns, String val, String operation) {
+
+        List<String> data =
+                Arrays.asList(
+                        "shardId",
+                        "indexName",
+                        operation,
+                        "shardRole",
+                        "transport",
+                        val,
+                        val,
+                        val,
+                        val);
+        when(metric.getFlowUnits())
+                .thenReturn(
+                        Collections.singletonList(
+                                new MetricFlowUnit(
+                                        0, metricTestHelper.createTestResult(columns, data))));
+    }
+}

--- a/src/test/java/org/opensearch/performanceanalyzer/rca/store/rca/hot_node/ThreadMetricsSlidingWindowTest.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/rca/store/rca/hot_node/ThreadMetricsSlidingWindowTest.java
@@ -12,8 +12,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.opensearch.performanceanalyzer.rca.GradleTaskForRca;
-import org.opensearch.performanceanalyzer.rca.store.rca.hot_node.ThreadMetricsRca.ThreadMetric;
-import org.opensearch.performanceanalyzer.rca.store.rca.hot_node.ThreadMetricsRca.ThreadMetricsSlidingWindow;
 
 @Category(GradleTaskForRca.class)
 public class ThreadMetricsSlidingWindowTest {

--- a/src/test/java/org/opensearch/performanceanalyzer/rca/store/rca/hot_node/ThreadMetricsSlidingWindowTest.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/rca/store/rca/hot_node/ThreadMetricsSlidingWindowTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.performanceanalyzer.rca.store.rca.hot_node;
+
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.opensearch.performanceanalyzer.rca.GradleTaskForRca;
+import org.opensearch.performanceanalyzer.rca.store.rca.hot_node.ThreadMetricsRca.ThreadMetric;
+import org.opensearch.performanceanalyzer.rca.store.rca.hot_node.ThreadMetricsRca.ThreadMetricsSlidingWindow;
+
+@Category(GradleTaskForRca.class)
+public class ThreadMetricsSlidingWindowTest {
+
+    @Test
+    public void testWindow() {
+        ThreadMetricsSlidingWindow window = new ThreadMetricsSlidingWindow();
+        Assert.assertEquals(window.getMaxSum(), 0d, 0d);
+        Assert.assertEquals(window.getCountExceedingThreshold(5d), 0d, 0);
+        long currentTimeMillis = 100L;
+        window.next(
+                currentTimeMillis,
+                Arrays.asList(
+                        new ThreadMetric("t1", 10d, currentTimeMillis, "operation"),
+                        new ThreadMetric("t2", 15d, currentTimeMillis, "operation")));
+        Assert.assertEquals(window.getMaxSum(), 15d, 0d);
+        Assert.assertEquals(window.getCountExceedingThreshold(5d), 2, 0);
+        Assert.assertEquals(window.getCountExceedingThreshold(10d), 1, 0);
+        currentTimeMillis = 30100L;
+        window.next(
+                currentTimeMillis,
+                Arrays.asList(
+                        new ThreadMetric("t1", 10d, currentTimeMillis, "operation"),
+                        new ThreadMetric("t2", 15d, currentTimeMillis, "operation"),
+                        new ThreadMetric("t3", 4d, currentTimeMillis, "operation")));
+        Assert.assertEquals(window.getMaxSum(), 30d, 0d);
+        Assert.assertEquals(window.getCountExceedingThreshold(5d), 2, 0);
+        Assert.assertEquals(window.getCountExceedingThreshold(10d), 2, 0);
+        currentTimeMillis = 40100L;
+        window.next(currentTimeMillis, Collections.emptyList());
+        Assert.assertEquals(window.getMaxSum(), 30d, 0d);
+        Assert.assertEquals(window.getCountExceedingThreshold(5d), 2, 0);
+        Assert.assertEquals(window.getCountExceedingThreshold(10d), 2, 0);
+        currentTimeMillis = 61101L;
+        window.next(currentTimeMillis, Collections.emptyList());
+        Assert.assertEquals(window.getMaxSum(), 15d, 0d);
+        Assert.assertEquals(window.getCountExceedingThreshold(5d), 2, 0);
+        Assert.assertEquals(window.getCountExceedingThreshold(10d), 1, 0);
+        currentTimeMillis = 111101L;
+        window.next(currentTimeMillis, Collections.emptyList());
+        Assert.assertEquals(window.getMaxSum(), 0, 0d);
+        Assert.assertEquals(window.getCountExceedingThreshold(5d), 0, 0);
+        Assert.assertEquals(window.getCountExceedingThreshold(10d), 0, 0);
+    }
+}


### PR DESCRIPTION

Adds an RCA which analyses thread blocked time value in the past 60 second window and publisher reader Metric stats for high thread blocked, waited time and count of threads blocked, waited longer than threshold in the past minute.



**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
