### PR TITLE
Update Libraries to fetch the updated netty patched with CVE-2022-24823

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -55,7 +55,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: kiranprakash154/performance-analyzer
-        ref: origin/netty
+        ref: origin/kp/update-netty-json
         path: ./tmp/performance-analyzer
     - name: Build PA gradle using the new RCA jar
       working-directory: ./tmp/performance-analyzer

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -55,7 +55,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: kiranprakash154/performance-analyzer
-        ref: origin/kp/update-netty-json
+        ref: kp/update-netty-json
         path: ./tmp/performance-analyzer
     - name: Build PA gradle using the new RCA jar
       working-directory: ./tmp/performance-analyzer

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -54,8 +54,8 @@ jobs:
     - name: Checkout Performance Analyzer
       uses: actions/checkout@v2
       with:
-        repository: opensearch-project/performance-analyzer
-        ref: main
+        repository: kiranprakash154/performance-analyzer
+        ref: origin/netty
         path: ./tmp/performance-analyzer
     - name: Build PA gradle using the new RCA jar
       working-directory: ./tmp/performance-analyzer

--- a/build.gradle
+++ b/build.gradle
@@ -335,6 +335,9 @@ dependencies {
     implementation group: 'com.google.protobuf', name: 'protobuf-java', version: '3.19.2'
     implementation 'io.grpc:grpc-netty:1.49.0'
     implementation 'io.grpc:grpc-protobuf:1.49.0'
+    implementation('io.netty:netty-transport-native-unix-common:4.1.79.Final') {
+        force = 'true'
+    }
     implementation 'io.grpc:grpc-stub:1.49.0'
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
 

--- a/build.gradle
+++ b/build.gradle
@@ -323,7 +323,7 @@ dependencies {
     implementation 'org.bouncycastle:bcpkix-jdk15on:1.70'
     implementation 'org.xerial:sqlite-jdbc:3.32.3.2'
     implementation 'com.google.guava:guava:30.1-jre'
-    implementation 'com.google.code.gson:gson:2.8.9'
+    implementation 'com.google.code.gson:gson:2.9.0'
     implementation 'org.checkerframework:checker-qual:3.5.0'
     implementation "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
     implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonDataBindVersion}"
@@ -333,9 +333,9 @@ dependencies {
     implementation group: 'commons-io', name: 'commons-io', version: '2.7'
     implementation group: 'com.google.errorprone', name: 'error_prone_annotations', version: '2.9.0'
     implementation group: 'com.google.protobuf', name: 'protobuf-java', version: '3.19.2'
-    implementation 'io.grpc:grpc-netty:1.44.0'
-    implementation 'io.grpc:grpc-protobuf:1.44.0'
-    implementation 'io.grpc:grpc-stub:1.44.0'
+    implementation 'io.grpc:grpc-netty:1.49.0'
+    implementation 'io.grpc:grpc-protobuf:1.49.0'
+    implementation 'io.grpc:grpc-stub:1.49.0'
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
 
     // JDK9+ has to run powermock 2+. https://github.com/powermock/powermock/issues/888


### PR DESCRIPTION
Signed-off-by: Kiran Prakash <awskiran@amazon.com>


**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
netty had a [CVE-2022-24823](https://nvd.nist.gov/vuln/detail/CVE-2022-24823) that was patched in [4.1.77.Final](https://github.com/netty/netty/security/advisories/GHSA-269q-hmxg-m83q)

PA RCA uses netty via grpc which updated the netty to 4.1.77.Final in [1.49.0](https://github.com/grpc/grpc-java/commit/7bd079749667df9b39ae39f410c15a1117c447ad)

**For a green build** - This is building off Performance Analyzer against my 
fork - kiranprakash154/performance-analyzer 
branch - kiranprakash154:kp/update-netty-json

**Next Steps:** 
1. Merge this PR
2. Rebase [the PR](https://github.com/opensearch-project/performance-analyzer/pull/273) in Performance Analyzer & merge
3. Create a followup PR here to revert the branch and repo to main and origin.

**Describe the solution you are proposing**
Update grpc version from 1.44.0 to 1.49.0


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
