### PR TITLE
[Backport] Update grpc to 1.49.0 and gson to 2.9.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -335,11 +335,11 @@ dependencies {
     implementation group: 'com.google.protobuf', name: 'protobuf-java', version: '3.19.2'
     implementation 'io.grpc:grpc-netty:1.49.0'
     implementation 'io.grpc:grpc-protobuf:1.49.0'
+    implementation 'io.grpc:grpc-stub:1.49.0'
+    implementation 'javax.annotation:javax.annotation-api:1.3.2'
     implementation('io.netty:netty-transport-native-unix-common:4.1.79.Final') {
         force = 'true'
     }
-    implementation 'io.grpc:grpc-stub:1.49.0'
-    implementation 'javax.annotation:javax.annotation-api:1.3.2'
 
     // JDK9+ has to run powermock 2+. https://github.com/powermock/powermock/issues/888
     testImplementation group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -323,7 +323,7 @@ dependencies {
     implementation 'org.bouncycastle:bcpkix-jdk15on:1.70'
     implementation 'org.xerial:sqlite-jdbc:3.32.3.2'
     implementation 'com.google.guava:guava:30.1-jre'
-    implementation 'com.google.code.gson:gson:2.8.9'
+    implementation 'com.google.code.gson:gson:2.9.0'
     implementation 'org.checkerframework:checker-qual:3.5.0'
     implementation "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
     implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonDataBindVersion}"
@@ -333,9 +333,12 @@ dependencies {
     implementation group: 'commons-io', name: 'commons-io', version: '2.7'
     implementation group: 'com.google.errorprone', name: 'error_prone_annotations', version: '2.9.0'
     implementation group: 'com.google.protobuf', name: 'protobuf-java', version: '3.19.2'
-    implementation 'io.grpc:grpc-netty:1.44.0'
-    implementation 'io.grpc:grpc-protobuf:1.44.0'
-    implementation 'io.grpc:grpc-stub:1.44.0'
+    implementation 'io.grpc:grpc-netty:1.49.0'
+    implementation 'io.grpc:grpc-protobuf:1.49.0'
+    implementation('io.netty:netty-transport-native-unix-common:4.1.79.Final') {
+        force = 'true'
+    }
+    implementation 'io.grpc:grpc-stub:1.49.0'
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
 
     // JDK9+ has to run powermock 2+. https://github.com/powermock/powermock/issues/888


### PR DESCRIPTION
Signed-off-by: Kiran Prakash <awskiran@amazon.com>
(cherry picked from commit 93c22e74e04c1ba635af7941a41b011beb3d15bf)

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
Backporting https://github.com/opensearch-project/performance-analyzer-rca/pull/230 but not referring to personal fork and branch.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
