### PR TITLE
revert docker-compose.yml env var change

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -33,7 +33,7 @@ services:
   opensearch2:
     container_name: opensearch2
     environment:
-      - node.clusterManager=false
+      - node.master=false
     image: opensearch/pa-rca:2.4
     mem_limit: 4g
     networks:


### PR DESCRIPTION
Signed-off-by: Kaushal Kumar <kshkmr@amazon.com>

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
This change is to revert the env var `node.clusterManager` as that will not let the docker container to spin up.

**Describe the solution you are proposing**
A clear and concise description of what you want to happen.

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
