### PR TITLE
[1.3] Update jackson to 2.14.1 and netty to 4.1.84.Final

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -296,8 +296,8 @@ dependencies {
         compile files("${System.properties['java.home']}/../lib/tools.jar")
     }
 
-    def jacksonVersion = "2.13.4"
-    def jacksonDatabindVersion = "2.13.4.2"
+    def jacksonVersion = "2.14.1"
+    def jacksonDatabindVersion = "2.14.1"
 
     compile 'org.jooq:jooq:3.10.8'
     compile 'org.bouncycastle:bcprov-jdk15on:1.70'
@@ -319,7 +319,7 @@ dependencies {
     implementation 'io.grpc:grpc-stub:1.49.0'
 
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
-    implementation('io.netty:netty-transport-native-unix-common:4.1.79.Final') {
+    implementation('io.netty:netty-transport-native-unix-common:4.1.84.Final') {
         force = 'true'
     }
 


### PR DESCRIPTION
Signed-off-by: Craig Perkins <cwperx@amazon.com>

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**

Updates jackson and jackson-databind to 2.14.1 and netty to 4.1.84.Final to match version from core's version.properties.

Related distribution build failure: https://github.com/opensearch-project/performance-analyzer/issues/337

### Check List
- [X] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
