### PR TITLE
Jackson 2.14.1 & netty 4.1.86 upgrades

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -315,8 +315,8 @@ dependencies {
         implementation files("${System.properties['java.home']}/../lib/tools.jar")
     }
 
-    def jacksonVersion = "2.13.4"
-    def jacksonDataBindVersion = "2.13.4.2"
+    def jacksonVersion = "2.14.1"
+    def jacksonDataBindVersion = "2.14.1"
 
     implementation 'org.jooq:jooq:3.10.8'
     implementation 'org.bouncycastle:bcprov-jdk15on:1.70'
@@ -335,7 +335,7 @@ dependencies {
     implementation group: 'com.google.protobuf', name: 'protobuf-java', version: '3.21.8'
     implementation 'io.grpc:grpc-netty:1.49.0'
     implementation 'io.grpc:grpc-protobuf:1.49.0'
-    implementation('io.netty:netty-transport-native-unix-common:4.1.79.Final') {
+    implementation('io.netty:netty-transport-native-unix-common:4.1.86.Final') {
         force = 'true'
     }
     implementation 'io.grpc:grpc-stub:1.49.0'


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
Netty upgrade fixes https://github.com/opensearch-project/performance-analyzer-rca/issues/260. Guava already on 30.1
Jackson upgrade related to https://github.com/opensearch-project/performance-analyzer-rca/issues/257

**Describe the solution you are proposing**
Update jackson to 2.14.1 & netty to 4.1.86

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
