### PR TITLE
Pin bcel version to 6.6.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -357,6 +357,16 @@ dependencies {
     testImplementation group: 'junit', name: 'junit', version: '4.12'
 }
 
+configurations.each {
+    c -> c.resolutionStrategy.dependencySubstitution {
+        all { DependencySubstitution dependency ->
+            if (dependency.requested.group == 'org.apache.bcel') {
+                dependency.useTarget 'org.apache.bcel:bcel:6.6.1'
+            }
+        }
+    }
+}
+
 protobuf {
     protoc {
         artifact = "com.google.protobuf:protoc:3.21.8"


### PR DESCRIPTION
Signed-off-by: Filip Drobnjakovic <drobnjakovicfilip@gmail.com>

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
#264 

**Describe the solution you are proposing**
According to https://github.com/spotbugs/spotbugs/discussions/2251 this bcel vulnerability doesn't affect SpotBugs. As there's no tentative date for a new SpotBugs release that would include the version bump from their side and as confirmed by some users from the mentioned issue, pinning the dependency by ourselves gets rid of the warning and doesn't break SpotBugs. As bcel is transitive dependency of a plugin, it has to be done with iterative dependency substitution.

**Describe alternatives you've considered**
Alternative would be to completely ignore warning as there's no real threat from it and wait for new SpotBugs version or to find and integrate SpotBugs alternatives which would be more complicated and wouldn't bring much benefit.


### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
