### PR TITLE
Run docker OS cluster with different JDK versions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -75,7 +75,7 @@ jobs:
     # Enable RCA for Integration Tests
     - name: Spin up Docker cluster for integ testing
       working-directory: ./tmp/performance-analyzer-rca
-      run: ./gradlew enableRca -Dbuild.jdk_version=${{matrix.java}}
+      run: ./gradlew enableRca -Dbuild.docker_jdk_ver=${{matrix.java}}
 
     # Run Integration Tests in PA
     - name: Run integration tests

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -75,7 +75,7 @@ jobs:
     # Enable RCA for Integration Tests
     - name: Spin up Docker cluster for integ testing
       working-directory: ./tmp/performance-analyzer-rca
-      run: ./gradlew enableRca
+      run: ./gradlew enableRca -Dbuild.jdk_version=${{matrix.java}}
 
     # Run Integration Tests in PA
     - name: Run integration tests

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ ext {
     opensearch_version = System.getProperty("opensearch.version", "3.0.0-SNAPSHOT")
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
     buildVersionQualifier = System.getProperty("build.version_qualifier", "")
+    jdkVersion = System.getProperty("build.jdk_version", "11")
 
     // 3.0.0-SNAPSHOT -> 3.0.0.0-SNAPSHOT
     version_tokens = opensearch_version.tokenize('-')
@@ -462,7 +463,7 @@ task buildDocker(type: Exec) {
     dependsOn(copyAllArtifacts)
 
     workingDir(dockerArtifactsDir)
-    commandLine 'docker', 'build', '-t', 'opensearch/pa-rca:3.0', '.'
+    commandLine 'docker', 'build', '-t', 'opensearch/pa-rca:3.0', '.', '--build-arg', "JDK_VER=${jdkVersion}"
 }
 
 task runDocker(type: Exec) {

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ ext {
     opensearch_version = System.getProperty("opensearch.version", "3.0.0-SNAPSHOT")
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
     buildVersionQualifier = System.getProperty("build.version_qualifier", "")
-    jdkVersion = System.getProperty("build.jdk_version", "11")
+    buildDockerJdkVersion = System.getProperty("build.docker_jdk_ver", "11")
 
     // 3.0.0-SNAPSHOT -> 3.0.0.0-SNAPSHOT
     version_tokens = opensearch_version.tokenize('-')
@@ -463,7 +463,7 @@ task buildDocker(type: Exec) {
     dependsOn(copyAllArtifacts)
 
     workingDir(dockerArtifactsDir)
-    commandLine 'docker', 'build', '-t', 'opensearch/pa-rca:3.0', '.', '--build-arg', "JDK_VER=${jdkVersion}"
+    commandLine 'docker', 'build', '-t', 'opensearch/pa-rca:3.0', '.', '--build-arg', "JDK_VER=${buildDockerJdkVersion}"
 }
 
 task runDocker(type: Exec) {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,15 +14,16 @@ ARG JDK_VER=11
 
 ENV PATH /usr/share/opensearch/bin:$PATH
 
-RUN if [[ "${JDK_VER}" = "11" ]] ; then \
-    curl -s https://download.java.net/java/GA/jdk11/13/GPL/openjdk-11.0.1_linux-x64_bin.tar.gz | tar -C /opt -zxf -; \
-    mkdir /opt/jdk ; \
-    mv -v /opt/jdk-11.0.1/* /opt/jdk; \
-elif [[ "${JDK_VER}" = "17" ]] ; then \
+RUN if [[ "${JDK_VER}" = "17" ]] ; then \
     curl -s https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_linux-x64_bin.tar.gz | tar -C /opt -zxf -; \
     mkdir /opt/jdk ; \
     mv -v /opt/jdk-17.0.2/* /opt/jdk; \
+else \
+    curl -s https://download.java.net/java/GA/jdk11/13/GPL/openjdk-11.0.1_linux-x64_bin.tar.gz | tar -C /opt -zxf -; \
+    mkdir /opt/jdk ; \
+    mv -v /opt/jdk-11.0.1/* /opt/jdk; \
 fi
+
 
 ENV OPENSEARCH_JAVA_HOME /opt/jdk
 RUN yum install -y unzip

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,10 +10,21 @@
 ################################################################################
 
 FROM centos:7 AS prep_open_search_files
+ARG JDK_VER=11
 
 ENV PATH /usr/share/opensearch/bin:$PATH
-RUN curl -s https://download.java.net/java/GA/jdk11/13/GPL/openjdk-11.0.1_linux-x64_bin.tar.gz | tar -C /opt -zxf -
-ENV OPENSEARCH_JAVA_HOME /opt/jdk-11.0.1
+
+RUN if [[ "${JDK_VER}" = "11" ]] ; then \
+    curl -s https://download.java.net/java/GA/jdk11/13/GPL/openjdk-11.0.1_linux-x64_bin.tar.gz | tar -C /opt -zxf -; \
+    mkdir /opt/jdk ; \
+    mv -v /opt/jdk-11.0.1/* /opt/jdk; \
+elif [[ "${JDK_VER}" = "17" ]] ; then \
+    curl -s https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_linux-x64_bin.tar.gz | tar -C /opt -zxf -; \
+    mkdir /opt/jdk ; \
+    mv -v /opt/jdk-17.0.2/* /opt/jdk; \
+fi
+
+ENV OPENSEARCH_JAVA_HOME /opt/jdk
 RUN yum install -y unzip
 RUN yum install -y lsof
 
@@ -54,6 +65,10 @@ RUN chown -R opensearch:0 . && \
 RUN unzip config/performance-analyzer-rca-3.0.0.0-SNAPSHOT.zip
 
 RUN chmod -R 755 /dev/shm
+
+RUN if [[ "${JDK_VER}" = "17" ]] ; then \
+    echo "--add-opens=jdk.attach/sun.tools.attach=ALL-UNNAMED" >> /usr/share/opensearch/config/jvm.options ; \
+fi
 ################################################################################
 # Build stage 1 (the actual OpenSearch image):
 # Copy OpenSearch from stage 0
@@ -86,13 +101,13 @@ RUN yum update -y && \
     yum install -y nc unzip wget which && \
     yum clean all
 COPY CENTOS_LICENSING.txt /root
-COPY --from=prep_open_search_files --chown=1000:0 /opt/jdk-11.0.1 /opt/jdk-11.0.1
-ENV OPENSEARCH_JAVA_HOME /opt/jdk-11.0.1
+COPY --from=prep_open_search_files --chown=1000:0 /opt/jdk /opt/jdk
+ENV OPENSEARCH_JAVA_HOME /opt/jdk
 ENV OPENSEARCH_PATH_CONF /usr/share/opensearch/config
 
 # Replace OpenJDK's built-in CA certificate keystore with the one from the OS
 # vendor. The latter is superior in several ways.
-RUN ln -sf /etc/pki/ca-trust/extracted/java/cacerts /opt/jdk-11.0.1/lib/security/cacerts
+RUN ln -sf /etc/pki/ca-trust/extracted/java/cacerts /opt/jdk/lib/security/cacerts
 
 ENV PATH $PATH:$OPENSEARCH_JAVA_HOME/bin
 


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
Issue #162

**Describe the solution you are proposing**
 Workflow matrix parameter is passed through gradle argument and then to Dockerfile where corresponding JDK version is downloaded and placed in the plain 'jdk' folder to reduce further parameterization and complication of Dockerfile.
 Also we add conditional jvm.options hack line because of #161, once it's solved we can get rid of it.  

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
