### PR TITLE
Fix netty dependency to not include vulnerable 4.1.79 version jars.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -335,7 +335,10 @@ dependencies {
     implementation group: 'com.google.protobuf', name: 'protobuf-java', version: '3.21.12'
     implementation 'io.grpc:grpc-netty:1.52.1'
     implementation 'io.grpc:grpc-protobuf:1.52.1'
-    implementation('io.netty:netty-transport-native-unix-common:4.1.86.Final') {
+    implementation('io.netty:netty-codec-http2:4.1.86.Final') {
+        force = 'true'
+    }
+    implementation('io.netty:netty-handler-proxy:4.1.86.Final') {
         force = 'true'
     }
     implementation 'io.grpc:grpc-stub:1.52.1'


### PR DESCRIPTION
This change forces the usage of netty 4.1.86.Final. grpc-netty 1.5.1 depends on the vuln versions, we were overriding the version for some of the included netty jars but not all.

Signed-off-by: Marc Handalian <handalm@amazon.com>

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

**Describe the solution you are proposing**
No 4.1.79.Final jars included in lib.

**Additional context**
Without this change:

```
./performance-analyzer-rca/lib/netty-common-4.1.86.Final.jar
./performance-analyzer-rca/lib/netty-transport-4.1.86.Final.jar
./performance-analyzer-rca/lib/netty-codec-http-4.1.77.Final.jar
./performance-analyzer-rca/lib/netty-codec-http2-4.1.77.Final.jar
./performance-analyzer-rca/lib/netty-handler-proxy-4.1.77.Final.jar
./performance-analyzer-rca/lib/netty-codec-4.1.77.Final.jar
./performance-analyzer-rca/lib/netty-buffer-4.1.86.Final.jar
./performance-analyzer-rca/lib/netty-transport-native-unix-common-4.1.86.Final.jar
./performance-analyzer-rca/lib/netty-handler-4.1.77.Final.jar
./performance-analyzer-rca/lib/netty-resolver-4.1.86.Final.jar
./performance-analyzer-rca/lib/netty-codec-socks-4.1.77.Final.jar
```

With this change:
```
netty-buffer-4.1.86.Final.jar
netty-codec-4.1.86.Final.jar
netty-codec-http-4.1.86.Final.jar
netty-codec-http2-4.1.86.Final.jar
netty-codec-socks-4.1.86.Final.jar
netty-common-4.1.86.Final.jar
netty-handler-4.1.86.Final.jar
netty-handler-proxy-4.1.86.Final.jar
netty-resolver-4.1.86.Final.jar
netty-transport-4.1.86.Final.jar
netty-transport-native-unix-common-4.1.86.Final.jar
```


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
