### PR TITLE
Fix GC types not being collected.

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/jvm/HeapMetrics.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/jvm/HeapMetrics.java
@@ -42,12 +42,14 @@ public class HeapMetrics {
             } else if ("Par Eden Space".equals(item.getName())
                     || "Eden Space".equals(item.getName())
                     || "PS Eden Space".equals(item.getName())
-                    || "G1 Eden".equals(item.getName())) {
+                    || "G1 Eden".equals(item.getName())
+                    || "G1 Eden Space".equals(item.getName())) {
                 memoryUsageSuppliers.put("Eden", () -> item.getUsage());
             } else if ("Par Survivor Space".equals(item.getName())
                     || "Survivor Space".equals(item.getName())
                     || "PS Survivor Space".equals(item.getName())
-                    || "G1 Survivor".equals(item.getName())) {
+                    || "G1 Survivor".equals(item.getName())
+                    || "G1 Survivor Space".equals(item.getName())) {
                 memoryUsageSuppliers.put("Survivor", () -> item.getUsage());
             }
         }

--- a/src/test/java/org/opensearch/performanceanalyzer/collectors/HeapMetricsCollectorGCTypesTest.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/collectors/HeapMetricsCollectorGCTypesTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.performanceanalyzer.collectors;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableSet;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.Assert;
+import org.junit.Test;
+import org.opensearch.performanceanalyzer.metrics.AllMetrics;
+import org.opensearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
+
+public class HeapMetricsCollectorGCTypesTest {
+    private static final ObjectMapper mapper = new ObjectMapper();
+    private static final HeapMetricsCollector uut = new HeapMetricsCollector();
+    private static final Set<String> gcTypes =
+            ImmutableSet.of(
+                    AllMetrics.GCType.HEAP.toString(),
+                    AllMetrics.GCType.NON_HEAP.toString(),
+                    AllMetrics.GCType.PERM_GEN.toString(),
+                    AllMetrics.GCType.OLD_GEN.toString(),
+                    AllMetrics.GCType.TOT_YOUNG_GC.toString(),
+                    AllMetrics.GCType.TOT_FULL_GC.toString(),
+                    AllMetrics.GCType.EDEN.toString(),
+                    AllMetrics.GCType.SURVIVOR.toString());
+
+    @Test
+    public void validateCollectedGCTypes() throws Exception {
+        Set<String> collectedGCTypes = new HashSet<>();
+
+        uut.collectMetrics(Instant.now().toEpochMilli());
+        String metricString = uut.getValue().toString();
+        int end = metricString.indexOf(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor);
+        metricString = metricString.substring(end + 1);
+
+        while (!metricString.isEmpty()) {
+            end = metricString.indexOf(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor);
+            String metric = metricString.substring(0, end);
+            HeapMetricsCollector.HeapStatus heapStatus =
+                    mapper.readValue(metric, HeapMetricsCollector.HeapStatus.class);
+            collectedGCTypes.add(heapStatus.getType());
+            metricString = metricString.substring(end + 1);
+        }
+
+        Assert.assertEquals(collectedGCTypes, gcTypes);
+    }
+}


### PR DESCRIPTION
Signed-off-by: Filip Drobnjakovic <drobnjakovicfilip@gmail.com>

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
#286 

**Describe the solution you are proposing**
By checking the `metricsdb_*` sqlite table (`Heap_Max`) manually it can be seen that both `Eden` and `Survivor` (the two types appearing in issue description) rows are missing and thus never being parsed and causing exceptions.

The roots of the problem go back to collector having hardcoded memory pool name sets when comparing to `MemoryMXBean`'s results. Collector then gets incomplete list of GCTypes and proceeds to emit them to tmp files that later end up as incomplete sql tables.

I added the new possible memory pool names that were missing so now collector succeeds in recognizing and collecting all the GC types. I added a unit test for this.
A also confirmed the fix by checking the `Heap_Max` tables by hand and we no longer get exceptions mentioned in issue. 

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
