### PR TITLE
Increase reader test coverage

### DIFF
--- a/src/test/java/org/opensearch/performanceanalyzer/reader/ClusterManagerThrottlingMetricsProcessorTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/reader/ClusterManagerThrottlingMetricsProcessorTests.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.performanceanalyzer.reader;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import org.jooq.Record;
+import org.jooq.Result;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.opensearch.performanceanalyzer.metrics.AllMetrics;
+import org.opensearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
+import org.opensearch.performanceanalyzer.reader_writer_shared.Event;
+
+public class ClusterManagerThrottlingMetricsProcessorTests {
+    private static final String DB_URL = "jdbc:sqlite:";
+    private static final Long PENDING_TASKS_NUM = 33L;
+    private static final String CMTM_KEY = "cluster_manager_throttling_metrics";
+    private static final String SERIALIZED_EVENT =
+            "{\"Data_RetryingPendingTasksCount\":0,\"ClusterManager_ThrottledPendingTasksCount\":33}";
+
+    private ClusterManagerThrottlingMetricsEventProcessor cmtmProcessor;
+    private long currTimestamp;
+    private NavigableMap<Long, ClusterManagerThrottlingMetricsSnapshot> snapMap;
+    Connection conn;
+
+    @Before
+    public void setup() throws Exception {
+        Class.forName("org.sqlite.JDBC");
+        System.setProperty("java.io.tmpdir", "/tmp");
+        conn = DriverManager.getConnection(DB_URL);
+        this.currTimestamp = System.currentTimeMillis();
+        this.snapMap = new TreeMap<>();
+        this.cmtmProcessor =
+                ClusterManagerThrottlingMetricsEventProcessor
+                        .buildClusterManagerThrottlingMetricEventsProcessor(
+                                currTimestamp, conn, snapMap);
+    }
+
+    @Test
+    public void testHandleEvent() {
+        Event testEvent = buildTestCMTMEvent();
+
+        cmtmProcessor.initializeProcessing(currTimestamp, System.currentTimeMillis());
+
+        assertTrue(cmtmProcessor.shouldProcessEvent(testEvent));
+
+        cmtmProcessor.processEvent(testEvent);
+        cmtmProcessor.finalizeProcessing();
+
+        ClusterManagerThrottlingMetricsSnapshot snap = snapMap.get(currTimestamp);
+        Result<Record> result = snap.fetchAll();
+        assertEquals(1, result.size());
+        Assert.assertEquals(
+                PENDING_TASKS_NUM,
+                result.get(0)
+                        .get(
+                                AllMetrics.ClusterManagerThrottlingValue
+                                        .CLUSTER_MANAGER_THROTTLED_PENDING_TASK_COUNT
+                                        .toString()));
+    }
+
+    private Event buildTestCMTMEvent() {
+        StringBuilder val = new StringBuilder();
+        val.append(PerformanceAnalyzerMetrics.getJsonCurrentMilliSeconds())
+                .append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor);
+
+        val.append(SERIALIZED_EVENT).append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor);
+
+        return new Event(CMTM_KEY, val.toString(), System.currentTimeMillis());
+    }
+}

--- a/src/test/java/org/opensearch/performanceanalyzer/reader/FileHandlerTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/reader/FileHandlerTests.java
@@ -22,7 +22,7 @@ public class FileHandlerTests {
     }
 
     @Test
-    public void testFindFiles() throws IOException {
+    public void testFindFiles() {
         FileHandler fileHandler = MetricPropertiesConfig.createFileHandler("indices", "path_elem");
         fileHandler.setRootLocation(rootLocation);
 
@@ -35,7 +35,7 @@ public class FileHandlerTests {
         FileHandler shardStateFileHandler = new MetricPropertiesConfig.ShardStatFileHandler();
         shardStateFileHandler.setRootLocation(rootLocation);
 
-        File file = new File(rootLocation + "15000000000000/indices/path_elem/123");
+        File file = new File(rootLocation + "15000000000000/indices/path_elem/15000000005000");
 
         String[] extraDimensions = shardStateFileHandler.processExtraDimensions(file);
         assertEquals(2, extraDimensions.length);

--- a/src/test/java/org/opensearch/performanceanalyzer/reader/FileHandlerTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/reader/FileHandlerTests.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.performanceanalyzer.reader;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+
+public class FileHandlerTests {
+    public String rootLocation;
+
+    @Before
+    public void setup() {
+        rootLocation = "build/resources/test/reader/";
+    }
+
+    @Test
+    public void testFindFiles() throws IOException {
+        FileHandler fileHandler = MetricPropertiesConfig.createFileHandler("indices", "path_elem");
+        fileHandler.setRootLocation(rootLocation);
+
+        List<File> files = fileHandler.findFiles4Metric(15000000000000L);
+        assertEquals(1, files.size());
+    }
+
+    @Test
+    public void testExtraDimensions() throws IOException {
+        FileHandler shardStateFileHandler = new MetricPropertiesConfig.ShardStatFileHandler();
+        shardStateFileHandler.setRootLocation(rootLocation);
+
+        File file = new File(rootLocation + "15000000000000/indices/path_elem/123");
+
+        String[] extraDimensions = shardStateFileHandler.processExtraDimensions(file);
+        assertEquals(2, extraDimensions.length);
+    }
+}

--- a/src/test/java/org/opensearch/performanceanalyzer/reader/ReaderMetricsProcessorTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/reader/ReaderMetricsProcessorTests.java
@@ -81,7 +81,7 @@ public class ReaderMetricsProcessorTests extends AbstractReaderTests {
                 assertNotNull(record.get("ShardBulkDocs"));
                 assertEquals(1519.0, (Double) record.get("ShardEvents"), 0.0);
                 assertEquals(507096.0, (Double) record.get("ShardBulkDocs"), 0.0);
-                assertTrue((Double) record.get("CPU_Utilization") > 1.0);
+                assertEquals(1.89, (Double) record.get("CPU_Utilization"), 0.02);
                 shardbulkEncountered = true;
             }
         }

--- a/src/test/java/org/opensearch/performanceanalyzer/reader/ReaderMetricsProcessorTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/reader/ReaderMetricsProcessorTests.java
@@ -60,6 +60,8 @@ public class ReaderMetricsProcessorTests extends AbstractReaderTests {
         ReaderMetricsProcessor mp =
                 new ReaderMetricsProcessor(rootLocation, true, new AppContext());
 
+        mp.processMetrics(rootLocation, 1566413975000L);
+        mp.processMetrics(rootLocation, 1566413980000L);
         mp.processMetrics(rootLocation, 1566413985000L);
         mp.processMetrics(rootLocation, 1566413990000L);
 
@@ -67,8 +69,8 @@ public class ReaderMetricsProcessorTests extends AbstractReaderTests {
                 mp.getMetricsDB()
                         .getValue()
                         .queryMetric(
-                                Arrays.asList("ShardEvents", "ShardBulkDocs"),
-                                Arrays.asList("sum", "sum"),
+                                Arrays.asList("ShardEvents", "ShardBulkDocs", "CPU_Utilization"),
+                                Arrays.asList("sum", "sum", "sum"),
                                 Arrays.asList("Operation"));
 
         boolean shardbulkEncountered = false;
@@ -79,6 +81,7 @@ public class ReaderMetricsProcessorTests extends AbstractReaderTests {
                 assertNotNull(record.get("ShardBulkDocs"));
                 assertEquals(1519.0, (Double) record.get("ShardEvents"), 0.0);
                 assertEquals(507096.0, (Double) record.get("ShardBulkDocs"), 0.0);
+                assertTrue((Double) record.get("CPU_Utilization") > 1.0);
                 shardbulkEncountered = true;
             }
         }

--- a/src/test/resources/reader/1566413960000
+++ b/src/test/resources/reader/1566413960000
@@ -10,7 +10,7 @@ $
 {"Election_Term":18}$
 ^cluster_manager_throttling_metrics
 {"current_time":1566413936555}
-{"Data_RetryingPendingTasksCount":0,"ClusterManager_ThrottledPendingTasksCount":33}
+{"Data_RetryingPendingTasksCount":0,"ClusterManager_ThrottledPendingTasksCount":33}$
 ^cluster_applier_service
 {"current_time":1566413936555}
 {"ClusterApplierService_Latency":23,"ClusterApplierService_Failure":3}$

--- a/src/test/resources/reader/1566413965000
+++ b/src/test/resources/reader/1566413965000
@@ -9,7 +9,7 @@ $
 {"Election_Term":18}$
 ^cluster_manager_throttling_metrics
 {"current_time":1566413966544}
-{"Data_RetryingPendingTasksCount":0,"ClusterManager_ThrottledPendingTasksCount":33}
+{"Data_RetryingPendingTasksCount":0,"ClusterManager_ThrottledPendingTasksCount":33}$
 ^cluster_applier_service
 {"current_time":1566413966544}
 {"ClusterApplierService_Latency":23,"ClusterApplierService_Failure":3}$

--- a/src/test/resources/reader/1566413970000
+++ b/src/test/resources/reader/1566413970000
@@ -10,7 +10,7 @@ $
 {"Election_Term":19}$
 ^cluster_manager_throttling_metrics
 {"current_time":1566413996947}
-{"Data_RetryingPendingTasksCount":0,"ClusterManager_ThrottledPendingTasksCount":33}
+{"Data_RetryingPendingTasksCount":0,"ClusterManager_ThrottledPendingTasksCount":33}$
 ^cluster_applier_service
 {"current_time":1566413996947}
 {"ClusterApplierService_Latency":23,"ClusterApplierService_Failure":3}$


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
#284

**Describe the solution you are proposing**

In this PR there is initially:
- Small unit tests for FileHandler (and some of it's subclasses) as it's a class with lowest % coverage.
- Unit test for ClusterManagerThrottlingMetricsProcessor.
- Fix for test resources where Cluster Manager Throttling Metrics didn't have end marker (`$`) and weren't parsed and emitted correctly which brought our coverage down by a lot.
- Doubling the amount of epochs parsed in the ReaderMetricsProcessorTest. This makes the alignment for OS metrics possible and triggers their emission (decent part of code we didn't have covered previously), which we confirm by inserting additional assertion for `CPU_Utilization`.

Besides this, we should consider removing dead code that I have mentioned in the issue comment.

**Describe alternatives you've considered**

**Additional context**
Regarding the invalid Cluster Manager Throttling Metrics in the test resources I initially suspected that they weren't written correctly, but the issue doesn't seem to exist as the [way all metrics are written to a tmp file](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/src/main/java/org/opensearch/performanceanalyzer/reader_writer_shared/EventLog.java#L57) is universal. Please someone point out if I'm wrong.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
