### PR TITLE
Fixing issue where GC type metrics are broken

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/jvm/GarbageCollectorInfo.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/jvm/GarbageCollectorInfo.java
@@ -45,11 +45,13 @@ public class GarbageCollectorInfo {
                         .put("Eden Space", EDEN)
                         .put("PS Eden Space", EDEN)
                         .put("G1 Eden", EDEN)
+                        .put("G1 Eden Space", EDEN)
                         // Survivor space as read by different collectors.
                         .put("Par Survivor Space", SURVIVOR)
                         .put("Survivor Space", SURVIVOR)
                         .put("PS Survivor Space", SURVIVOR)
                         .put("G1 Survivor", SURVIVOR)
+                        .put("G1 Survivor Space", SURVIVOR)
                         .build();
 
         List<GarbageCollectorMXBean> gcBeans = ManagementFactory.getGarbageCollectorMXBeans();


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
https://github.com/opensearch-project/performance-analyzer-rca/issues/286
- Plugin writes GC info which is read by RCA and dumped into metricsDB. New memory pools were introduced which needs to be handled. This change is for that. 

**Describe the solution you are proposing**
- Adding new memory pool type

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context - Testing**
- Tested by spinning up a opensearch cluster. 
- Before fix, plugin was writing below in tempfs
```
^gc_info
{"current_time":1677621728046}
{"MemoryPool":"OldGen","CollectorName":"G1 Young Generation"}
{"MemoryPool":"G1 Survivor Space","CollectorName":"G1 Young Generation"}
{"MemoryPool":"G1 Eden Space","CollectorName":"G1 Young Generation"}
$
```
- After fix:
```
^gc_info
{"current_time":1677634035342}
{"MemoryPool":"Survivor","CollectorName":"G1 Young Generation"}
{"MemoryPool":"OldGen","CollectorName":"G1 Young Generation"}
{"MemoryPool":"Eden","CollectorName":"G1 Young Generation"}
$
```
- After fix, ,metricsDB tables
```
sqlite> select * from GC_Type;
Survivor|G1 Young Generation||||
OldGen|G1 Young Generation||||
Eden|G1 Young Generation||||
```
```
sqlite> select * from Heap_Max;
Eden|-1.0|-1.0|-1.0|-1.0
Heap|4294967296.0|4294967296.0|4294967296.0|4294967296.0
NonHeap|-1.0|-1.0|-1.0|-1.0
OldGen|4294967296.0|4294967296.0|4294967296.0|4294967296.0
PermGen|-1.0|-1.0|-1.0|-1.0
Survivor|-1.0|-1.0|-1.0|-1.0
totFullGC|-2.0|-2.0|-2.0|-2.0
totYoungGC|-2.0|-2.0|-2.0|-2.0
```


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
