### PR TITLE
Move PA log from /tmp

### DIFF
--- a/config/log4j2.xml
+++ b/config/log4j2.xml
@@ -4,26 +4,32 @@
         <Console name="Console" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />
         </Console>
-        <RollingFile name="PerformanceAnalyzerLog" fileName="/tmp/PerformanceAnalyzer.log" filePattern="/tmp/PerformanceAnalyzer.log.%d{yyyy-MM-dd}-%i.gz" immediateFlush="true" append="true">
+        <RollingFile name="PerformanceAnalyzerLog"
+                     fileName="${sys:opensearch.path.home:-/tmp}/logs/PerformanceAnalyzer.log"
+                     filePattern="${sys:opensearch.path.home:-/tmp}/logs/PerformanceAnalyzer.log.%d{yyyy-MM-dd}-%i.gz"
+                     immediateFlush="true" append="true">
             <PatternLayout pattern="%d{yyy-MM-dd HH:mm:ss.SSS} [PA:Reader] [%t] %-5level %logger{36} - %msg%n"/>
             <Policies>
                 <TimeBasedTriggeringPolicy interval="1" modulate="true"/>
                 <SizeBasedTriggeringPolicy size="128 MB"/>
             </Policies>
             <DefaultRolloverStrategy>
-                <Delete basePath="/tmp">
+                <Delete basePath="${sys:opensearch.path.home:-/tmp}/logs">
                     <IfFileName glob="PerformanceAnalyzer.log.*.gz" />
                     <IfAccumulatedFileSize exceeds="2 GB" />
                 </Delete>
             </DefaultRolloverStrategy>
         </RollingFile>
-        <RollingFile name="StatsLog" fileName="/tmp/performance_analyzer_agent_stats.log" filePattern="/tmp/performance_analyzer_agent_stats.log.%d{yyyy-MM-dd}-%i.gz" immediateFlush="true" append="true">
+        <RollingFile name="StatsLog"
+                     fileName="${sys:opensearch.path.home:-/tmp}/logs/performance_analyzer_agent_stats.log"
+                     filePattern="${sys:opensearch.path.home:-/tmp}/logs/performance_analyzer_agent_stats.log.%d{yyyy-MM-dd}-%i.gz"
+                     immediateFlush="true" append="true">
             <Policies>
                 <TimeBasedTriggeringPolicy interval="1" modulate="true"/>
                 <SizeBasedTriggeringPolicy size="128 MB"/>
             </Policies>
             <DefaultRolloverStrategy>
-                <Delete basePath="/tmp">
+                <Delete basePath="${sys:opensearch.path.home:-/tmp}/logs/">
                     <IfFileName glob="performance_analyzer_agent_stats.log.*.gz" />
                     <IfAccumulatedFileSize exceeds="2 GB" />
                 </Delete>


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
Related to PA log bloating issue - https://github.com/opensearch-project/performance-analyzer/issues/226

Also need to change `performance-analyzer.log` to `PerformanceAnalyzer.log` [here](https://github.com/search?q=org%3Aopensearch-project+performance-analyzer.log&type=code)

**Describe the solution you are proposing**
Move PA log out of `/tmp` to `${sys:opensearch.path.home}/logs/PerformanceAnalyzer.log`. `/usr/share/opensearch/logs/` in most cases.
```
[root@1dbf5d5a3f52 opensearch]# pwd
/usr/share/opensearch

[root@1dbf5d5a3f52 opensearch]# ls logs/
PerformanceAnalyzer.log  gc.log  gc.log.00  performance_analyzer_agent_stats.log

[root@1dbf5d5a3f52 opensearch]# ls /tmp/
hsperfdata_opensearch  metricsdb_1680656190000  opensearch-12473103827612193397                                        sqlite-3.32.3.2-52bda654-fa6c-465e-9a28-9501bea6db2d-libsqlitejdbc.so.lck
ks-script-DrRL8A       metricsdb_1680656195000  sqlite-3.32.3.2-52bda654-fa6c-465e-9a28-9501bea6db2d-libsqlitejdbc.so  yum.log
```

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
