### PR TITLE
Add Latency Metrics for respective Emitters in Reader Event Processing

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/rca/RcaController.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/RcaController.java
@@ -43,7 +43,6 @@ import org.opensearch.performanceanalyzer.rca.framework.core.Stats;
 import org.opensearch.performanceanalyzer.rca.framework.core.ThresholdMain;
 import org.opensearch.performanceanalyzer.rca.framework.metrics.ExceptionsAndErrors;
 import org.opensearch.performanceanalyzer.rca.framework.metrics.RcaRuntimeMetrics;
-import org.opensearch.performanceanalyzer.rca.framework.metrics.ReaderMetrics;
 import org.opensearch.performanceanalyzer.rca.framework.util.InstanceDetails;
 import org.opensearch.performanceanalyzer.rca.framework.util.RcaConsts;
 import org.opensearch.performanceanalyzer.rca.framework.util.RcaUtil;
@@ -283,8 +282,8 @@ public class RcaController {
     private void restart() {
         stop();
         start();
-        PerformanceAnalyzerApp.READER_METRICS_AGGREGATOR.updateStat(
-                ReaderMetrics.RCA_SCHEDULER_RESTART, "", 1);
+        PerformanceAnalyzerApp.RCA_RUNTIME_METRICS_AGGREGATOR.updateStat(
+                RcaRuntimeMetrics.RCA_SCHEDULER_RESTART, "", 1);
     }
 
     protected RcaConf getRcaConfForMyRole(AllMetrics.NodeRole role) {

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/framework/metrics/ExceptionsAndErrors.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/framework/metrics/ExceptionsAndErrors.java
@@ -42,6 +42,21 @@ public enum ExceptionsAndErrors implements MeasurementSet {
      */
     EXCEPTION_IN_PERSIST("ExceptionInPersist", "namedCount", Statistics.NAMED_COUNTERS),
 
+    BATCH_METRICS_CONFIG_ERROR("BatchMetricsConfigError", "count", Statistics.SAMPLE),
+
+    /** Number of http requests where the client gave a bad request. */
+    BATCH_METRICS_HTTP_CLIENT_ERROR("BatchMetricsHttpClientError", "count", Statistics.COUNT),
+
+    /** Number of http requests where the host could not generate a correct response. */
+    BATCH_METRICS_HTTP_HOST_ERROR("BatchMetricsHttpHostError", "count", Statistics.COUNT),
+
+    /**
+     * Number of times a query for batch metrics exceeded the maximum number of requestable
+     * datapoints.
+     */
+    BATCH_METRICS_EXCEEDED_MAX_DATAPOINTS(
+            "ExceededBatchMetricsMaxDatapoints", "count", Statistics.COUNT),
+
     /** When the reader encounters errors accessing metricsdb files. */
     READER_METRICSDB_ACCESS_ERRORS("ReaderMetricsdbAccessError"),
 

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/framework/metrics/RcaGraphMetrics.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/framework/metrics/RcaGraphMetrics.java
@@ -17,12 +17,7 @@ public enum RcaGraphMetrics implements MeasurementSet {
     GRAPH_EXECUTION_TIME(
             "RcaGraphExecution",
             "millis",
-            Arrays.asList(
-                    Statistics.MAX,
-                    Statistics.MIN,
-                    Statistics.MEAN,
-                    Statistics.COUNT,
-                    Statistics.SUM)),
+            Arrays.asList(Statistics.MAX, Statistics.MEAN, Statistics.SUM)),
 
     /** Measures the time spent in the operate() method of a graph node. */
     GRAPH_NODE_OPERATE_CALL(
@@ -66,7 +61,7 @@ public enum RcaGraphMetrics implements MeasurementSet {
     /** Measures the time spent in the persistence layer. */
     RCA_PERSIST_CALL(
             "RcaPersistCall",
-            "micros",
+            "millis",
             Arrays.asList(Statistics.MAX, Statistics.MEAN, Statistics.SUM)),
 
     /** Number of nodes that are currently publishing flow units to downstream nodes. */

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/framework/metrics/RcaRuntimeMetrics.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/framework/metrics/RcaRuntimeMetrics.java
@@ -12,6 +12,13 @@ import org.opensearch.performanceanalyzer.rca.stats.eval.Statistics;
 import org.opensearch.performanceanalyzer.rca.stats.measurements.MeasurementSet;
 
 public enum RcaRuntimeMetrics implements MeasurementSet {
+    /**
+     * Tracks scheduler restart issued at {@link
+     * org.opensearch.performanceanalyzer.rca.RcaController#restart}
+     */
+    RCA_SCHEDULER_RESTART(
+            "RcaSchedulerRestart", "count", Collections.singletonList(Statistics.COUNT)),
+
     /** The number of times the framework was stopped by the operator. */
     RCA_STOPPED_BY_OPERATOR(
             "RcaStoppedByOperator", "count", Collections.singletonList(Statistics.COUNT)),

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/framework/metrics/ReaderMetrics.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/framework/metrics/ReaderMetrics.java
@@ -6,11 +6,12 @@
 package org.opensearch.performanceanalyzer.rca.framework.metrics;
 
 
+import org.opensearch.performanceanalyzer.rca.stats.eval.Statistics;
+import org.opensearch.performanceanalyzer.rca.stats.measurements.MeasurementSet;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import org.opensearch.performanceanalyzer.rca.stats.eval.Statistics;
-import org.opensearch.performanceanalyzer.rca.stats.measurements.MeasurementSet;
 
 public enum ReaderMetrics implements MeasurementSet {
 
@@ -18,10 +19,12 @@ public enum ReaderMetrics implements MeasurementSet {
      * We start 6 threads within RCA Agent, details at {@link
      * org.opensearch.performanceanalyzer.PerformanceAnalyzerThreads}. Below metrics track count of
      * thread started and ended.
+     *
+     * <p>Note: The 'PA' in metricName is confusing, it is meant to imply threads started within RCA
+     * Agent.
      */
     NUM_PA_THREADS_STARTED(
             "NumberOfPAThreadsStarted", "namedCount", Collections.singletonList(Statistics.COUNT)),
-
     NUM_PA_THREADS_ENDED(
             "NumberOfPAThreadsEnded", "namedCount", Collections.singletonList(Statistics.COUNT)),
 
@@ -33,79 +36,127 @@ public enum ReaderMetrics implements MeasurementSet {
      */
     READER_THREAD_STOPPED(
             "ReaderThreadStopped", "count", Collections.singletonList(Statistics.COUNT)),
-
     ERROR_HANDLER_THREAD_STOPPED(
             "ErrorHandlerThreadStopped", "count", Collections.singletonList(Statistics.COUNT)),
-
     GRPC_SERVER_THREAD_STOPPED(
             "GRPCServerThreadStopped", "count", Collections.singletonList(Statistics.COUNT)),
-
     WEB_SERVER_THREAD_STOPPED(
             "WebServerThreadStopped", "count", Collections.singletonList(Statistics.COUNT)),
-
     RCA_CONTROLLER_THREAD_STOPPED(
             "RcaControllerThreadStopped", "count", Collections.singletonList(Statistics.COUNT)),
-
     RCA_SCHEDULER_THREAD_STOPPED(
             "RcaSchedulerThreadStopped", "count", Collections.singletonList(Statistics.COUNT)),
 
-    /** Tracks time taken by Reader thread to emit event metrics . */
-    READER_METRICS_EMIT_TIME(
-            "ReaderMetricsEmitTime",
-            "millis",
-            Arrays.asList(Statistics.MAX, Statistics.MEAN, Statistics.SUM)),
-
     /**
-     * Tracks scheduler restart issued at {@link
-     * org.opensearch.performanceanalyzer.rca.RcaController#restart}
+     * Tracks MetricDB related metrics, the size of below metricDB file is factor of events(shard +
+     * cluster traffic) and also the collector functioning.
      */
-    RCA_SCHEDULER_RESTART(
-            "RcaSchedulerRestart", "count", Collections.singletonList(Statistics.COUNT)),
-
-    /** Size of generated metricsdb files. */
     METRICSDB_FILE_SIZE(
             "MetricsdbFileSize", "bytes", Arrays.asList(Statistics.MAX, Statistics.MEAN)),
-
-    /** Number of compressed and uncompressed metricsdb files. */
     METRICSDB_NUM_FILES("MetricsdbNumFiles", "count", Statistics.SAMPLE),
-
-    /** Size of compressed and uncompressed metricsdb files. */
     METRICSDB_SIZE_FILES("MetricsdbSizeFiles", "bytes", Statistics.SAMPLE),
-
-    /** Number of uncompressed metricsdb files. */
     METRICSDB_NUM_UNCOMPRESSED_FILES("MetricsdbNumUncompressedFiles", "count", Statistics.SAMPLE),
-
-    /** Size of uncompressed metricsdb files. */
     METRICSDB_SIZE_UNCOMPRESSED_FILES("MetricsdbSizeUncompressedFiles", "bytes", Statistics.SAMPLE),
-
-    /** Whether or not batch metrics is enabled (0 for enabled, 1 for disabled). */
     BATCH_METRICS_ENABLED("BatchMetricsEnabled", "count", Statistics.SAMPLE),
-
-    BATCH_METRICS_CONFIG_ERROR("BatchMetricsConfigError", "count", Statistics.SAMPLE),
-
-    /** Number of http requests where the client gave a bad request. */
-    BATCH_METRICS_HTTP_CLIENT_ERROR("BatchMetricsHttpClientError", "count", Statistics.COUNT),
-
-    /** Number of http requests where the host could not generate a correct response. */
-    BATCH_METRICS_HTTP_HOST_ERROR("BatchMetricsHttpHostError", "count", Statistics.COUNT),
-
-    /** Number of successful queries. */
     BATCH_METRICS_HTTP_SUCCESS("BatchMetricsHttpSuccess", "count", Statistics.COUNT),
-
-    /**
-     * Number of times a query for batch metrics exceeded the maximum number of requestable
-     * datapoints.
-     */
-    BATCH_METRICS_EXCEEDED_MAX_DATAPOINTS(
-            "ExceededBatchMetricsMaxDatapoints", "count", Statistics.COUNT),
-
-    /** Amount of time required to process valid batch metrics requests. */
     BATCH_METRICS_QUERY_PROCESSING_TIME(
             "BatchMetricsQueryProcessingTime",
             "millis",
             Arrays.asList(Statistics.MAX, Statistics.MEAN, Statistics.SUM)),
 
-    /** Amount of time taken to emit Shard State metrics. */
+    /**
+     * Tracks time taken by respective emitters and the total time to process and emit event
+     * metrics.
+     */
+    READER_METRICS_EMIT_TIME(
+            "ReaderMetricsEmitTime",
+            "millis",
+            Arrays.asList(Statistics.MAX, Statistics.MEAN, Statistics.SUM)),
+    READER_METRICS_PROCESS_TIME(
+            "ReaderMetricsProcessTime",
+            "millis",
+            Arrays.asList(Statistics.MAX, Statistics.MEAN, Statistics.SUM)),
+    GC_INFO_EMITTER_EXECUTION_TIME(
+            "GCInfoEmitterExecutionTime",
+            "millis",
+            Arrays.asList(
+                    Statistics.MAX,
+                    Statistics.MIN,
+                    Statistics.MEAN,
+                    Statistics.COUNT,
+                    Statistics.SUM)),
+    WORKLOAD_METRICS_EMITTER_EXECUTION_TIME(
+            "WorkloadMetricsEmitterExecutionTime",
+            "millis",
+            Arrays.asList(
+                    Statistics.MAX,
+                    Statistics.MIN,
+                    Statistics.MEAN,
+                    Statistics.COUNT,
+                    Statistics.SUM)),
+    THREAD_NAME_METRICS_EMITTER_EXECUTION_TIME(
+            "ThreadNameMetricsEmitterExecutionTime",
+            "millis",
+            Arrays.asList(
+                    Statistics.MAX,
+                    Statistics.MIN,
+                    Statistics.MEAN,
+                    Statistics.COUNT,
+                    Statistics.SUM)),
+    AGGREGATED_OS_METRICS_EMITTER_EXECUTION_TIME(
+            "AggregatedOSMetricsEmitterExecutionTime",
+            "millis",
+            Arrays.asList(
+                    Statistics.MAX,
+                    Statistics.MIN,
+                    Statistics.MEAN,
+                    Statistics.COUNT,
+                    Statistics.SUM)),
+    SHARD_REQUEST_METRICS_EMITTER_EXECUTION_TIME(
+            "ShardRequestMetricsEmitterExecutionTime",
+            "millis",
+            Arrays.asList(
+                    Statistics.MAX,
+                    Statistics.MIN,
+                    Statistics.MEAN,
+                    Statistics.COUNT,
+                    Statistics.SUM)),
+    HTTP_METRICS_EMITTER_EXECUTION_TIME(
+            "HTTPMetricsEmitterExecutionTime",
+            "millis",
+            Arrays.asList(
+                    Statistics.MAX,
+                    Statistics.MIN,
+                    Statistics.MEAN,
+                    Statistics.COUNT,
+                    Statistics.SUM)),
+    ADMISSION_CONTROL_METRICS_EMITTER_EXECUTION_TIME(
+            "AdmissionControlMetricsEmitterExecutionTime",
+            "millis",
+            Arrays.asList(
+                    Statistics.MAX,
+                    Statistics.MIN,
+                    Statistics.MEAN,
+                    Statistics.COUNT,
+                    Statistics.SUM)),
+    CLUSTER_MANAGER_EVENT_METRICS_EMITTER_EXECUTION_TIME(
+            "ClusterManagerEventMetricsEmitterExecutionTime",
+            "millis",
+            Arrays.asList(
+                    Statistics.MAX,
+                    Statistics.MIN,
+                    Statistics.MEAN,
+                    Statistics.COUNT,
+                    Statistics.SUM)),
+    NODE_METRICS_EMITTER_EXECUTION_TIME(
+            "NodeMetricsEmitterExecutionTime",
+            "millis",
+            Arrays.asList(
+                    Statistics.MAX,
+                    Statistics.MIN,
+                    Statistics.MEAN,
+                    Statistics.COUNT,
+                    Statistics.SUM)),
     SHARD_STATE_EMITTER_EXECUTION_TIME(
             "ShardStateEmitterExecutionTime",
             "millis",
@@ -115,8 +166,6 @@ public enum ReaderMetrics implements MeasurementSet {
                     Statistics.MEAN,
                     Statistics.COUNT,
                     Statistics.SUM)),
-
-    /** Amount of time taken to emit ClusterManager throttling metrics. */
     CLUSTER_MANAGER_THROTTLING_EMITTER_EXECUTION_TIME(
             "ClusterManagerThrottlingEmitterExecutionTime",
             "millis",
@@ -126,7 +175,6 @@ public enum ReaderMetrics implements MeasurementSet {
                     Statistics.MEAN,
                     Statistics.COUNT,
                     Statistics.SUM)),
-
     FAULT_DETECTION_METRICS_EMITTER_EXECUTION_TIME(
             "FaultDetectionMetricsEmitterExecutionTime",
             "millis",

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/framework/metrics/ReaderMetrics.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/framework/metrics/ReaderMetrics.java
@@ -6,12 +6,11 @@
 package org.opensearch.performanceanalyzer.rca.framework.metrics;
 
 
-import org.opensearch.performanceanalyzer.rca.stats.eval.Statistics;
-import org.opensearch.performanceanalyzer.rca.stats.measurements.MeasurementSet;
-
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import org.opensearch.performanceanalyzer.rca.stats.eval.Statistics;
+import org.opensearch.performanceanalyzer.rca.stats.measurements.MeasurementSet;
 
 public enum ReaderMetrics implements MeasurementSet {
 
@@ -79,111 +78,51 @@ public enum ReaderMetrics implements MeasurementSet {
     GC_INFO_EMITTER_EXECUTION_TIME(
             "GCInfoEmitterExecutionTime",
             "millis",
-            Arrays.asList(
-                    Statistics.MAX,
-                    Statistics.MIN,
-                    Statistics.MEAN,
-                    Statistics.COUNT,
-                    Statistics.SUM)),
+            Arrays.asList(Statistics.MAX, Statistics.MEAN, Statistics.SUM)),
     WORKLOAD_METRICS_EMITTER_EXECUTION_TIME(
             "WorkloadMetricsEmitterExecutionTime",
             "millis",
-            Arrays.asList(
-                    Statistics.MAX,
-                    Statistics.MIN,
-                    Statistics.MEAN,
-                    Statistics.COUNT,
-                    Statistics.SUM)),
+            Arrays.asList(Statistics.MAX, Statistics.MEAN, Statistics.SUM)),
     THREAD_NAME_METRICS_EMITTER_EXECUTION_TIME(
             "ThreadNameMetricsEmitterExecutionTime",
             "millis",
-            Arrays.asList(
-                    Statistics.MAX,
-                    Statistics.MIN,
-                    Statistics.MEAN,
-                    Statistics.COUNT,
-                    Statistics.SUM)),
+            Arrays.asList(Statistics.MAX, Statistics.MEAN, Statistics.SUM)),
     AGGREGATED_OS_METRICS_EMITTER_EXECUTION_TIME(
             "AggregatedOSMetricsEmitterExecutionTime",
             "millis",
-            Arrays.asList(
-                    Statistics.MAX,
-                    Statistics.MIN,
-                    Statistics.MEAN,
-                    Statistics.COUNT,
-                    Statistics.SUM)),
+            Arrays.asList(Statistics.MAX, Statistics.MEAN, Statistics.SUM)),
     SHARD_REQUEST_METRICS_EMITTER_EXECUTION_TIME(
             "ShardRequestMetricsEmitterExecutionTime",
             "millis",
-            Arrays.asList(
-                    Statistics.MAX,
-                    Statistics.MIN,
-                    Statistics.MEAN,
-                    Statistics.COUNT,
-                    Statistics.SUM)),
+            Arrays.asList(Statistics.MAX, Statistics.MEAN, Statistics.SUM)),
     HTTP_METRICS_EMITTER_EXECUTION_TIME(
             "HTTPMetricsEmitterExecutionTime",
             "millis",
-            Arrays.asList(
-                    Statistics.MAX,
-                    Statistics.MIN,
-                    Statistics.MEAN,
-                    Statistics.COUNT,
-                    Statistics.SUM)),
+            Arrays.asList(Statistics.MAX, Statistics.MEAN, Statistics.SUM)),
     ADMISSION_CONTROL_METRICS_EMITTER_EXECUTION_TIME(
             "AdmissionControlMetricsEmitterExecutionTime",
             "millis",
-            Arrays.asList(
-                    Statistics.MAX,
-                    Statistics.MIN,
-                    Statistics.MEAN,
-                    Statistics.COUNT,
-                    Statistics.SUM)),
+            Arrays.asList(Statistics.MAX, Statistics.MEAN, Statistics.SUM)),
     CLUSTER_MANAGER_EVENT_METRICS_EMITTER_EXECUTION_TIME(
             "ClusterManagerEventMetricsEmitterExecutionTime",
             "millis",
-            Arrays.asList(
-                    Statistics.MAX,
-                    Statistics.MIN,
-                    Statistics.MEAN,
-                    Statistics.COUNT,
-                    Statistics.SUM)),
+            Arrays.asList(Statistics.MAX, Statistics.MEAN, Statistics.SUM)),
     NODE_METRICS_EMITTER_EXECUTION_TIME(
             "NodeMetricsEmitterExecutionTime",
             "millis",
-            Arrays.asList(
-                    Statistics.MAX,
-                    Statistics.MIN,
-                    Statistics.MEAN,
-                    Statistics.COUNT,
-                    Statistics.SUM)),
+            Arrays.asList(Statistics.MAX, Statistics.MEAN, Statistics.SUM)),
     SHARD_STATE_EMITTER_EXECUTION_TIME(
             "ShardStateEmitterExecutionTime",
             "millis",
-            Arrays.asList(
-                    Statistics.MAX,
-                    Statistics.MIN,
-                    Statistics.MEAN,
-                    Statistics.COUNT,
-                    Statistics.SUM)),
+            Arrays.asList(Statistics.MAX, Statistics.MEAN, Statistics.SUM)),
     CLUSTER_MANAGER_THROTTLING_EMITTER_EXECUTION_TIME(
             "ClusterManagerThrottlingEmitterExecutionTime",
             "millis",
-            Arrays.asList(
-                    Statistics.MAX,
-                    Statistics.MIN,
-                    Statistics.MEAN,
-                    Statistics.COUNT,
-                    Statistics.SUM)),
+            Arrays.asList(Statistics.MAX, Statistics.MEAN, Statistics.SUM)),
     FAULT_DETECTION_METRICS_EMITTER_EXECUTION_TIME(
             "FaultDetectionMetricsEmitterExecutionTime",
             "millis",
-            Arrays.asList(
-                    Statistics.MAX,
-                    Statistics.MIN,
-                    Statistics.MEAN,
-                    Statistics.COUNT,
-                    Statistics.SUM)),
+            Arrays.asList(Statistics.MAX, Statistics.MEAN, Statistics.SUM)),
 
     /** Number of transport threads in BLOCKED state. */
     BLOCKED_TRANSPORT_THREAD_COUNT("BlockedTransportThreadCount", "count", Statistics.MAX),

--- a/src/main/java/org/opensearch/performanceanalyzer/reader/MetricsEmitter.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/reader/MetricsEmitter.java
@@ -53,7 +53,6 @@ public class MetricsEmitter {
     private static final Pattern FLUSH_PATTERN = Pattern.compile(".*opensearch.*\\[flush\\].*");
     // Version 6.4 onwards uses write threadpool.
     private static final Pattern WRITE_PATTERN = Pattern.compile(".*opensearch.*\\[write\\].*");
-    // Pattern otherPattern = Pattern.compile(".*(opensearch).*");
     private static final Pattern HTTP_SERVER_PATTERN =
             Pattern.compile(".*opensearch.*\\[http_server_worker\\].*");
     private static final Pattern TRANS_WORKER_PATTERN =
@@ -292,6 +291,8 @@ public class MetricsEmitter {
         }
         mFinalT = System.currentTimeMillis();
         LOG.debug("Total time taken for writing resource metrics metricsdb: {}", mFinalT - mCurrT);
+        PerformanceAnalyzerApp.READER_METRICS_AGGREGATOR.updateStat(
+                ReaderMetrics.AGGREGATED_OS_METRICS_EMITTER_EXECUTION_TIME, "", mFinalT - mCurrT);
     }
 
     /**
@@ -459,6 +460,8 @@ public class MetricsEmitter {
         }
         long mFinalT = System.currentTimeMillis();
         LOG.debug("Total time taken for writing workload metrics metricsdb: {}", mFinalT - mCurrT);
+        PerformanceAnalyzerApp.READER_METRICS_AGGREGATOR.updateStat(
+                ReaderMetrics.WORKLOAD_METRICS_EMITTER_EXECUTION_TIME, "", mFinalT - mCurrT);
     }
 
     public static void emitThreadNameMetrics(
@@ -497,6 +500,8 @@ public class MetricsEmitter {
         long mFinalT = System.currentTimeMillis();
         LOG.debug(
                 "Total time taken for writing threadName metrics metricsdb: {}", mFinalT - mCurrT);
+        PerformanceAnalyzerApp.READER_METRICS_AGGREGATOR.updateStat(
+                ReaderMetrics.THREAD_NAME_METRICS_EMITTER_EXECUTION_TIME, "", mFinalT - mCurrT);
     }
 
     public static String categorizeThreadName(String threadName, Dimensions dimensions) {
@@ -693,6 +698,8 @@ public class MetricsEmitter {
 
         long mFinalT = System.currentTimeMillis();
         LOG.debug("Total time taken for writing http metrics metricsdb: {}", mFinalT - mCurrT);
+        PerformanceAnalyzerApp.READER_METRICS_AGGREGATOR.updateStat(
+                ReaderMetrics.HTTP_METRICS_EMITTER_EXECUTION_TIME, "", mFinalT - mCurrT);
     }
 
     public static void emitGarbageCollectionInfo(
@@ -738,12 +745,13 @@ public class MetricsEmitter {
         LOG.debug(
                 "Total time taken for writing garbage collection info into metricsDB: {}",
                 mFinalT - mCurrT);
+        PerformanceAnalyzerApp.READER_METRICS_AGGREGATOR.updateStat(
+                ReaderMetrics.GC_INFO_EMITTER_EXECUTION_TIME, "", mFinalT - mCurrT);
     }
 
     public static void emitAdmissionControlMetrics(
             MetricsDB metricsDB, AdmissionControlSnapshot snapshot) {
-
-        long startTime = System.currentTimeMillis();
+        long mCurrT = System.currentTimeMillis();
         Result<Record> records = snapshot.fetchAll();
 
         List<String> dims =
@@ -787,10 +795,14 @@ public class MetricsEmitter {
 
         handle.execute();
 
-        long endTime = System.currentTimeMillis();
+        long mFinalT = System.currentTimeMillis();
         LOG.debug(
                 "Total time taken for writing AdmissionControl into metricsDB: {}",
-                endTime - startTime);
+                mFinalT - mCurrT);
+        PerformanceAnalyzerApp.READER_METRICS_AGGREGATOR.updateStat(
+                ReaderMetrics.ADMISSION_CONTROL_METRICS_EMITTER_EXECUTION_TIME,
+                "",
+                mFinalT - mCurrT);
     }
 
     public static void emitClusterManagerEventMetrics(
@@ -829,8 +841,13 @@ public class MetricsEmitter {
         LOG.debug(
                 "Total time taken for writing cluster_manager event queue metrics metricsdb: {}",
                 mFinalT - mCurrT);
+        PerformanceAnalyzerApp.READER_METRICS_AGGREGATOR.updateStat(
+                ReaderMetrics.CLUSTER_MANAGER_EVENT_METRICS_EMITTER_EXECUTION_TIME,
+                "",
+                mFinalT - mCurrT);
     }
 
+    // TODO: Refactor and remove this out into metric-specific emitter
     private static void emitRuntimeMetric(
             MetricsDB metricsDB, Result<Record> res, List<String> dims) {
 
@@ -921,6 +938,7 @@ public class MetricsEmitter {
         handle.execute();
     }
 
+    // TODO: Refactor and remove this out into metric-specific emitter
     private static void emitQueueTimeMetric(
             MetricsDB metricsDB, Result<Record> res, List<String> dims) {
 
@@ -1071,6 +1089,8 @@ public class MetricsEmitter {
                     "Total time taken for writing {} metrics metricsdb: {}",
                     tableName,
                     mFinalT - mCurrT);
+            PerformanceAnalyzerApp.READER_METRICS_AGGREGATOR.updateStat(
+                    ReaderMetrics.NODE_METRICS_EMITTER_EXECUTION_TIME, "", mFinalT - mCurrT);
         }
     }
 
@@ -1218,11 +1238,11 @@ public class MetricsEmitter {
             }
         }
         long mFinalT = System.currentTimeMillis();
-        PerformanceAnalyzerApp.READER_METRICS_AGGREGATOR.updateStat(
-                ReaderMetrics.FAULT_DETECTION_METRICS_EMITTER_EXECUTION_TIME, "", mFinalT - mCurrT);
         LOG.debug(
                 "Total time taken for writing fault detection metrics to metricsdb: {}",
                 mFinalT - mCurrT);
+        PerformanceAnalyzerApp.READER_METRICS_AGGREGATOR.updateStat(
+                ReaderMetrics.FAULT_DETECTION_METRICS_EMITTER_EXECUTION_TIME, "", mFinalT - mCurrT);
     }
 
     public static void emitClusterManagerThrottledTaskMetric(
@@ -1246,6 +1266,7 @@ public class MetricsEmitter {
                 mFinalT - mCurrT);
     }
 
+    // TODO: Refactor and remove this out into metric-specific emitter
     public static void emitClusterManagerThrottlingCount(
             MetricsDB metricsDB, Result<Record> res, List<String> dims) {
         metricsDB.createMetric(
@@ -1317,6 +1338,7 @@ public class MetricsEmitter {
         handle.execute();
     }
 
+    // TODO: Refactor and remove this out into metric-specific emitter
     public static void emitDataThrottlingRetryingCount(
             MetricsDB metricsDB, Result<Record> res, List<String> dims) {
         metricsDB.createMetric(

--- a/src/main/java/org/opensearch/performanceanalyzer/rest/QueryBatchRequestHandler.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rest/QueryBatchRequestHandler.java
@@ -212,30 +212,30 @@ public class QueryBatchRequestHandler extends MetricsHandler implements HttpHand
             LOG.error(
                     "QueryException {} ExceptionCode: {}.",
                     e,
-                    ReaderMetrics.BATCH_METRICS_HTTP_HOST_ERROR,
+                    ExceptionsAndErrors.BATCH_METRICS_HTTP_HOST_ERROR,
                     e);
-            PerformanceAnalyzerApp.READER_METRICS_AGGREGATOR.updateStat(
-                    ReaderMetrics.BATCH_METRICS_HTTP_HOST_ERROR, "", 1);
+            PerformanceAnalyzerApp.ERRORS_AND_EXCEPTIONS_AGGREGATOR.updateStat(
+                    ExceptionsAndErrors.BATCH_METRICS_HTTP_HOST_ERROR, "", 1);
             String response = "{\"error\":\"" + e.toString() + "\"}";
             sendResponse(exchange, response, HttpURLConnection.HTTP_INTERNAL_ERROR);
         } catch (InvalidParameterException e) {
             LOG.error(
                     "QueryException {} ExceptionCode: {}.",
                     e,
-                    ReaderMetrics.BATCH_METRICS_HTTP_CLIENT_ERROR,
+                    ExceptionsAndErrors.BATCH_METRICS_HTTP_CLIENT_ERROR,
                     e);
-            PerformanceAnalyzerApp.READER_METRICS_AGGREGATOR.updateStat(
-                    ReaderMetrics.BATCH_METRICS_HTTP_CLIENT_ERROR, "", 1);
+            PerformanceAnalyzerApp.ERRORS_AND_EXCEPTIONS_AGGREGATOR.updateStat(
+                    ExceptionsAndErrors.BATCH_METRICS_HTTP_CLIENT_ERROR, "", 1);
             String response = "{\"error\":\"" + e.getMessage() + ".\"}";
             sendResponse(exchange, response, HttpURLConnection.HTTP_BAD_REQUEST);
         } catch (Exception e) {
             LOG.error(
                     "QueryException {} ExceptionCode: {}.",
                     e,
-                    ReaderMetrics.BATCH_METRICS_HTTP_HOST_ERROR,
+                    ExceptionsAndErrors.BATCH_METRICS_HTTP_HOST_ERROR,
                     e);
-            PerformanceAnalyzerApp.READER_METRICS_AGGREGATOR.updateStat(
-                    ReaderMetrics.BATCH_METRICS_HTTP_HOST_ERROR, "", 1);
+            PerformanceAnalyzerApp.ERRORS_AND_EXCEPTIONS_AGGREGATOR.updateStat(
+                    ExceptionsAndErrors.BATCH_METRICS_HTTP_HOST_ERROR, "", 1);
             String response = "{\"error\":\"" + e.toString() + "\"}";
             sendResponse(exchange, response, HttpURLConnection.HTTP_INTERNAL_ERROR);
         }
@@ -261,8 +261,8 @@ public class QueryBatchRequestHandler extends MetricsHandler implements HttpHand
             if (results != null) {
                 maxDatapoints -= results.size();
                 if (maxDatapoints <= 0) {
-                    PerformanceAnalyzerApp.READER_METRICS_AGGREGATOR.updateStat(
-                            ReaderMetrics.BATCH_METRICS_EXCEEDED_MAX_DATAPOINTS, "", 1);
+                    PerformanceAnalyzerApp.ERRORS_AND_EXCEPTIONS_AGGREGATOR.updateStat(
+                            ExceptionsAndErrors.BATCH_METRICS_EXCEEDED_MAX_DATAPOINTS, "", 1);
                     throw new InvalidParameterException(
                             String.format(
                                     "requested data exceeds the %d datapoints limit",
@@ -282,8 +282,10 @@ public class QueryBatchRequestHandler extends MetricsHandler implements HttpHand
                     if (results != null) {
                         maxDatapoints -= results.size();
                         if (maxDatapoints <= 0) {
-                            PerformanceAnalyzerApp.READER_METRICS_AGGREGATOR.updateStat(
-                                    ReaderMetrics.BATCH_METRICS_EXCEEDED_MAX_DATAPOINTS, "", 1);
+                            PerformanceAnalyzerApp.ERRORS_AND_EXCEPTIONS_AGGREGATOR.updateStat(
+                                    ExceptionsAndErrors.BATCH_METRICS_EXCEEDED_MAX_DATAPOINTS,
+                                    "",
+                                    1);
                             throw new InvalidParameterException(
                                     String.format(
                                             "requested data exceeds the %d datapoints limit",

--- a/src/test/java/org/opensearch/performanceanalyzer/rca/stats/measurements/MeasurementSetTestHelper.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/rca/stats/measurements/MeasurementSetTestHelper.java
@@ -13,13 +13,13 @@ import org.opensearch.performanceanalyzer.rca.stats.eval.Statistics;
 public enum MeasurementSetTestHelper implements MeasurementSet {
     TEST_MEASUREMENT1(
             "TestMeasurement1",
-            "micros",
+            "millis",
             Arrays.asList(Statistics.MAX, Statistics.MEAN, Statistics.MIN)),
-    TEST_MEASUREMENT2("TestMeasurement2", "micros", Arrays.asList(Statistics.COUNT)),
-    TEST_MEASUREMENT3("TestMeasurement3", "micros", Arrays.asList(Statistics.COUNT)),
-    TEST_MEASUREMENT4("TestMeasurement4", "micros", Arrays.asList(Statistics.SAMPLE)),
-    TEST_MEASUREMENT5("TestMeasurement5", "micros", Arrays.asList(Statistics.SUM)),
-    TEST_MEASUREMENT6("TestMeasurement6", "micros", Arrays.asList(Statistics.NAMED_COUNTERS)),
+    TEST_MEASUREMENT2("TestMeasurement2", "millis", Arrays.asList(Statistics.COUNT)),
+    TEST_MEASUREMENT3("TestMeasurement3", "millis", Arrays.asList(Statistics.COUNT)),
+    TEST_MEASUREMENT4("TestMeasurement4", "millis", Arrays.asList(Statistics.SAMPLE)),
+    TEST_MEASUREMENT5("TestMeasurement5", "millis", Arrays.asList(Statistics.SUM)),
+    TEST_MEASUREMENT6("TestMeasurement6", "millis", Arrays.asList(Statistics.NAMED_COUNTERS)),
     JVM_FREE_MEM_SAMPLER("jvmFreeMemorySampler", "bytes", Arrays.asList(Statistics.SAMPLE));
 
     private String name;

--- a/src/test/java/org/opensearch/performanceanalyzer/reader/ReaderMetricsProcessorTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/reader/ReaderMetricsProcessorTests.java
@@ -42,7 +42,7 @@ import org.opensearch.performanceanalyzer.metrics.MetricsConfiguration;
 import org.opensearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
 import org.opensearch.performanceanalyzer.metricsdb.MetricsDB;
 import org.opensearch.performanceanalyzer.rca.RcaTestHelper;
-import org.opensearch.performanceanalyzer.rca.framework.metrics.ReaderMetrics;
+import org.opensearch.performanceanalyzer.rca.framework.metrics.ExceptionsAndErrors;
 
 public class ReaderMetricsProcessorTests extends AbstractReaderTests {
     public String rootLocation;
@@ -436,7 +436,7 @@ public class ReaderMetricsProcessorTests extends AbstractReaderTests {
         assertTrue(
                 mp.getBatchMetricsEnabled() == ReaderMetricsProcessor.defaultBatchMetricsEnabled);
 
-        assertTrue(RcaTestHelper.verify(ReaderMetrics.BATCH_METRICS_CONFIG_ERROR));
+        assertTrue(RcaTestHelper.verify(ExceptionsAndErrors.BATCH_METRICS_CONFIG_ERROR));
     }
 
     @Test


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
https://github.com/opensearch-project/performance-analyzer-rca/issues/363

**Describe the solution you are proposing**
* Adding Latency metrics for *emission* operation all the metric buckets
* Minor refactoring of different operations metric catgories

Tested by spinning up a docker container on local (`./gradlew runDocker`):

```
etrics=ClusterManagerThrottlingEmitterExecutionTime=13.0 millis aggr|MEAN,ClusterManagerThrottlingEmitterExecutionTime=299 millis aggr|SUM,ClusterManagerThrottlingEmitterExecutionTime=57 millis aggr|MAX,
ThreadNameMetricsEmitterExecutionTime=44 millis aggr|SUM,ThreadNameMetricsEmitterExecutionTime=2.0 millis aggr|MEAN,ThreadNameMetricsEmitterExecutionTime=9 millis aggr|MAX,
FaultDetectionMetricsEmitterExecutionTime=298 millis aggr|SUM,FaultDetectionMetricsEmitterExecutionTime=53 millis aggr|MAX,
FaultDetectionMetricsEmitterExecutionTime=12.956521739130435 millis aggr|MEAN,
AggregatedOSMetricsEmitterExecutionTime=270 millis aggr|MAX,
AggregatedOSMetricsEmitterExecutionTime=1189 millis aggr|SUM,AggregatedOSMetricsEmitterExecutionTime=54.04545454545455 millis aggr|MEAN,AdmissionControlMetricsEmitterExecutionTime=27 millis aggr|MAX,
AdmissionControlMetricsEmitterExecutionTime=141 millis aggr|SUM,AdmissionControlMetricsEmitterExecutionTime=6.130434782608695 millis aggr|MEAN,ReaderMetricsProcessTime=19815 millis aggr|SUM,ReaderMetricsProcessTime=2532.0 millis aggr|MAX,
ReaderMetricsProcessTime=421.59574468085106 millis aggr|MEAN,NumberOfPAThreadsEnded=1 namedCount aggr|COUNT,ClusterManagerEventMetricsEmitterExecutionTime=77 millis aggr|MAX,
ClusterManagerEventMetricsEmitterExecutionTime=22.652173913043477 millis aggr|MEAN,ClusterManagerEventMetricsEmitterExecutionTime=521 millis aggr|SUM,GCInfoEmitterExecutionTime=292 millis aggr|MAX,
GCInfoEmitterExecutionTime=561 millis aggr|SUM,GCInfoEmitterExecutionTime=23.375 millis aggr|MEAN,ShardStateEmitterExecutionTime=7.0 millis aggr|MEAN,ShardStateEmitterExecutionTime=161 millis aggr|SUM,ShardStateEmitterExecutionTime=22 millis aggr|MAX,
MetricsdbFileSize=141994.66666666666 bytes aggr|MEAN,MetricsdbFileSize=155648 bytes aggr|MAX,
HTTPMetricsEmitterExecutionTime=22.083333333333332 millis aggr|MEAN,HTTPMetricsEmitterExecutionTime=530 millis aggr|SUM,HTTPMetricsEmitterExecutionTime=215 millis aggr|MAX,
WorkloadMetricsEmitterExecutionTime=1106 millis aggr|SUM,WorkloadMetricsEmitterExecutionTime=581 millis aggr|MAX,
WorkloadMetricsEmitterExecutionTime=46.083333333333336 millis aggr|MEAN,NumberOfPAThreadsStarted=5 namedCount aggr|COUNT,ReaderMetricsEmitTime=15159 millis aggr|SUM,ReaderMetricsEmitTime=309.3673469387755 millis aggr|MEAN,ReaderMetricsEmitTime=1772.0 millis aggr|MAX,
ShardRequestMetricsEmitterExecutionTime=1023 millis aggr|MAX,ShardRequestMetricsEmitterExecutionTime=3599 millis aggr|SUM,ShardRequestMetricsEmitterExecutionTime=149.95833333333334 millis aggr|MEAN
```

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
