### PR TITLE
Add SHA update for PA-Commons to gradle.yml

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -59,7 +59,7 @@ jobs:
         path: ./tmp/performance-analyzer
     - name: Build PA gradle using the new RCA jar
       working-directory: ./tmp/performance-analyzer
-      run: rm -f licenses/performanceanalyzer-rca-*.jar.sha1
+      run: rm -f licenses/performanceanalyzer-rca-*.jar.sha1 licenses/performance-analyzer-commons-*.jar.sha1
     - name: Update SHA
       working-directory: ./tmp/performance-analyzer
       run: ./gradlew updateShas


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
Build failure see on the main branch due to SHA update for PA-Commons repo
```
Execution failed for task ':dependencyLicenses'.
> SHA has changed! Expected 055767b20346a5db502354b93b199f4d8aad19d7 for performance-analyzer-commons-1.0.0-SNAPSHOT.jar but got c5e251c139d5c635bc24c6d5d12ff9508faa3174.
  This usually indicates a corrupt dependency cache or artifacts changed upstream.
  Either wipe your cache, fix the upstream artifact, or delete /home/runner/work/performance-analyzer-rca/performance-analyzer-rca/tmp/performance-analyzer/licenses/performance-analyzer-commons-1.0.0-SNAPSHOT.jar.sha1 and run updateShas
```

**Describe the solution you are proposing**
Add SHA update to gradle.yml
Successful build: https://github.com/khushbr/performance-analyzer-rca/actions/runs/5126763338/jobs/9221665560

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
