### PR TITLE
Use org.jboss.spec.javax.annotation from core in place of javax.annotation

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -59,7 +59,7 @@ jobs:
         path: ./tmp/performance-analyzer
     - name: Build PA gradle using the new RCA jar
       working-directory: ./tmp/performance-analyzer
-      run: rm -f licenses/performanceanalyzer-rca-*.jar.sha1
+      run: rm -f licenses/performanceanalyzer-rca-*.jar.sha1 licenses/performance-analyzer-commons-*.jar.sha1
     - name: Update SHA
       working-directory: ./tmp/performance-analyzer
       run: ./gradlew updateShas

--- a/build.gradle
+++ b/build.gradle
@@ -336,6 +336,7 @@ dependencies {
     def log4jVersion = "${versions.log4j}"
     def protobufVersion = "${versions.protobuf}"
     def guavaVersion = "${versions.guava}"
+    def jbossVersion = "${versions.jboss_annotation}"
 
     implementation 'org.jooq:jooq:3.10.8'
     implementation 'org.bouncycastle:bcprov-jdk15on:1.70'
@@ -362,7 +363,7 @@ dependencies {
         force = 'true'
     }
     implementation 'io.grpc:grpc-stub:1.52.1'
-    implementation 'javax.annotation:javax.annotation-api:1.3.2'
+    implementation "org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:${jbossVersion}"
 
     // JDK9+ has to run powermock 2+. https://github.com/powermock/powermock/issues/888
     testImplementation group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.0'


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
Side-effect of https://github.com/opensearch-project/OpenSearch/pull/7604, this is causing JAR Hell when spinning up cluster with RCA present. 

```
> Task :paBwcCluster#oldVersionClusterTask1 FAILED
Exec output and error:
| Output for ./bin/opensearch-plugin:-> Installing file:/Users/khushbr/.gradle/caches/modules-2/files-2.1/org.opensearch.plugin/performance-analyzer/2.8.0.0-SNAPSHOT/d2825b5a621d43f484f5028e9f31078ef0768270/performance-analyzer-2.8.0.0-SNAPSHOT.zip
| -> Downloading file:/Users/khushbr/.gradle/caches/modules-2/files-2.1/org.opensearch.plugin/performance-analyzer/2.8.0.0-SNAPSHOT/d2825b5a621d43f484f5028e9f31078ef0768270/performance-analyzer-2.8.0.0-SNAPSHOT.zip
| -> Failed installing file:/Users/khushbr/.gradle/caches/modules-2/files-2.1/org.opensearch.plugin/performance-analyzer/2.8.0.0-SNAPSHOT/d2825b5a621d43f484f5028e9f31078ef0768270/performance-analyzer-2.8.0.0-SNAPSHOT.zip
| -> Rolling back file:/Users/khushbr/.gradle/caches/modules-2/files-2.1/org.opensearch.plugin/performance-analyzer/2.8.0.0-SNAPSHOT/d2825b5a621d43f484f5028e9f31078ef0768270/performance-analyzer-2.8.0.0-SNAPSHOT.zip
| -> Rolled back file:/Users/khushbr/.gradle/caches/modules-2/files-2.1/org.opensearch.plugin/performance-analyzer/2.8.0.0-SNAPSHOT/d2825b5a621d43f484f5028e9f31078ef0768270/performance-analyzer-2.8.0.0-SNAPSHOT.zip
| Exception in thread "main" java.lang.IllegalStateException: failed to load plugin opensearch-performance-analyzer due to jar hell
|       at org.opensearch.plugins.PluginsService.checkBundleJarHell(PluginsService.java:681)
|       at org.opensearch.plugins.InstallPluginCommand.jarHellCheck(InstallPluginCommand.java:862)
|       at org.opensearch.plugins.InstallPluginCommand.loadPluginInfo(InstallPluginCommand.java:830)
|       at org.opensearch.plugins.InstallPluginCommand.installPlugin(InstallPluginCommand.java:875)
|       at org.opensearch.plugins.InstallPluginCommand.execute(InstallPluginCommand.java:276)
|       at org.opensearch.plugins.InstallPluginCommand.execute(InstallPluginCommand.java:250)
|       at org.opensearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:104)
|       at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138)
|       at org.opensearch.cli.MultiCommand.execute(MultiCommand.java:104)
|       at org.opensearch.cli.Command.mainWithoutErrorHandling(Command.java:138)
|       at org.opensearch.cli.Command.main(Command.java:101)
|       at org.opensearch.plugins.PluginCli.main(PluginCli.java:60)
| Caused by: java.lang.IllegalStateException: jar hell!
| class: javax.annotation.sql.DataSourceDefinitions
| jar1: /Users/khushbr/Desktop/GITHUB/performance-analyzer/build/testclusters/paBwcCluster1-0/distro/2.8.0-ARCHIVE/lib/jboss-annotations-api_1.2_spec-1.0.2.Final.jar
| jar2: /Users/khushbr/Desktop/GITHUB/performance-analyzer/build/testclusters/paBwcCluster1-0/distro/2.8.0-ARCHIVE/plugins/.installing-7513005115664575767/javax.annotation-api-1.3.2.jar
|       at org.opensearch.bootstrap.JarHell.checkClass(JarHell.java:316)
|       at org.opensearch.bootstrap.JarHell.checkJarHell(JarHell.java:215)

```

**Describe the solution you are proposing**
Use org.jboss.spec.javax.annotation from core in place of javax.annotation


### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
