### PR TITLE
Revert Javax annotations dependency from core

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -336,7 +336,6 @@ dependencies {
     def log4jVersion = "${versions.log4j}"
     def protobufVersion = "${versions.protobuf}"
     def guavaVersion = "${versions.guava}"
-    def jbossVersion = "${versions.jboss_annotation}"
 
     implementation 'org.jooq:jooq:3.10.8'
     implementation 'org.bouncycastle:bcprov-jdk15on:1.70'
@@ -363,7 +362,7 @@ dependencies {
         force = 'true'
     }
     implementation 'io.grpc:grpc-stub:1.52.1'
-    implementation "org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:${jbossVersion}"
+    implementation 'javax.annotation:javax.annotation-api:1.3.2'
 
     // JDK9+ has to run powermock 2+. https://github.com/powermock/powermock/issues/888
     testImplementation group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.0'


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
https://github.com/opensearch-project/OpenSearch/pull/7604 has not been backported to 2.8 yet, and thus, it is causing the 2.8 dist PA build to break. This change addresses the failure. 
```
Could not determine the dependencies of task ':distTar'.

> Could not resolve all task dependencies for configuration ':runtimeClasspath'.

   > Could not find org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:null.

     Searched in the following locations:

       - https://repo.maven.apache.org/maven2/org/jboss/spec/javax/annotation/jboss-annotations-api_1.2_spec/null/jboss-annotations-api_1.2_spec-null.pom

       - file:/usr/share/opensearch/.m2/repository/org/jboss/spec/javax/annotation/jboss-annotations-api_1.2_spec/null/jboss-annotations-api_1.2_spec-null.pom

       - https://aws.oss.sonatype.org/content/repositories/snapshots/org/jboss/spec/javax/annotation/jboss-annotations-api_1.2_spec/null/jboss-annotations-api_1.2_spec-null.pom

     Required by:

         project :
```


### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
