### PR TITLE
Swap jboss annotation dependency for jakarta annotations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -336,7 +336,7 @@ dependencies {
     def log4jVersion = "${versions.log4j}"
     def protobufVersion = "${versions.protobuf}"
     def guavaVersion = "${versions.guava}"
-    def jbossVersion = "${versions.jboss_annotation}"
+    def jakartaVersion = "${versions.jakarta_annotation}"
 
     implementation 'org.jooq:jooq:3.10.8'
     implementation 'org.bouncycastle:bcprov-jdk15on:1.70'
@@ -363,7 +363,7 @@ dependencies {
         force = 'true'
     }
     implementation 'io.grpc:grpc-stub:1.52.1'
-    implementation "org.jboss.spec.javax.annotation:jboss-annotations-api_1.2_spec:${jbossVersion}"
+    implementation "jakarta.annotation:jakarta.annotation-api:${jakartaVersion}"
 
     // JDK9+ has to run powermock 2+. https://github.com/powermock/powermock/issues/888
     testImplementation group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.0'


### PR DESCRIPTION
Due to [PR on core](https://github.com/opensearch-project/OpenSearch/pull/7836).


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
