### PR TITLE
Update plugin artifact name in Dockerfile

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -436,6 +436,7 @@ task pullPAPlugin(type: Copy) {
     println String.format('opensearch_version: (%s), plugin_version: (%s), snapshot: (%s), qualifier: (%s).', opensearch_version, version, isSnapshot, buildVersionQualifier)
     from(configurations.dockerBuild)
     into(paDir)
+    rename "performance-analyzer-${version}.${file_ext}", "opensearch-performance-analyzer-${version}.${file_ext}"
     println String.format('Pulled PA Plugin at: (%s), will be used for Docker Build', Paths.get(paDir, "performance-analyzer-${version}.${file_ext}"))
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -437,7 +437,7 @@ task pullPAPlugin(type: Copy) {
     from(configurations.dockerBuild)
     into(paDir)
     rename "performance-analyzer-${version}.${file_ext}", "opensearch-performance-analyzer-${version}.${file_ext}"
-    println String.format('Pulled PA Plugin at: (%s), will be used for Docker Build', Paths.get(paDir, "performance-analyzer-${version}.${file_ext}"))
+    println String.format('Pulled PA Plugin at: (%s), will be used for Docker Build', Paths.get(paDir, "opensearch-performance-analyzer-${version}.${file_ext}"))
 }
 
 task copyAllArtifacts(type: Copy) {
@@ -445,7 +445,7 @@ task copyAllArtifacts(type: Copy) {
     def projectPathStr = getProjectDir().toPath().toString()
     def dockerArtifacts = Paths.get(projectPathStr, 'docker').toString()
     def rcaArtifacts = Paths.get(projectPathStr, 'build', 'distributions', "performance-analyzer-rca-${version}.${file_ext}")
-    def paArtifacts = Paths.get(dockerBuildDir, 'pa', "performance-analyzer-${version}.${file_ext}")
+    def paArtifacts = Paths.get(dockerBuildDir, 'pa', "opensearch-performance-analyzer-${version}.${file_ext}")
 
     dockerArtifactsDir = Paths.get(dockerBuildDir, 'rca-docker')
     mkdir dockerArtifactsDir

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,10 +52,10 @@ COPY --chown=1000:0 opensearch.yml log4j2.properties config/
 
 COPY --chown=1000:0 performance-analyzer-rca-3.0.0.0-SNAPSHOT.zip config/
 
-COPY --chown=1000:0 performance-analyzer-3.0.0.0-SNAPSHOT.zip /tmp/
+COPY --chown=1000:0 opensearch-performance-analyzer-3.0.0.0-SNAPSHOT.zip /tmp/
 
-RUN opensearch-plugin install --batch file:///tmp/performance-analyzer-3.0.0.0-SNAPSHOT.zip; \
-        rm /tmp/performance-analyzer-3.0.0.0-SNAPSHOT.zip
+RUN opensearch-plugin install --batch file:///tmp/opensearch-performance-analyzer-3.0.0.0-SNAPSHOT.zip; \
+        rm /tmp/opensearch-performance-analyzer-3.0.0.0-SNAPSHOT.zip
 USER 0
 
 # Set gid to 0 for opensearch and make group permission similar to that of user


### PR DESCRIPTION
According to the naming convention for plugin files, `opensearch-` prefix is kept for the build name and Dockerfile is updated to match that. #413 .

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
