### PR TITLE
Change the logic of RCA conditional execution tag system

### DIFF
--- a/config/rca_cluster_manager.conf
+++ b/config/rca_cluster_manager.conf
@@ -21,7 +21,7 @@
   "max-flow-units-per-vertex-buffer": 200,
 
   "tags": {
-    "locus": "cluster_manager-node"
+    "locus": "cluster_manager-node,data-node"
   },
 
   "remote-peers": ["ip1", "ip2", "ip3"],

--- a/config/rca_idle_cluster_manager.conf
+++ b/config/rca_idle_cluster_manager.conf
@@ -21,7 +21,7 @@
   "max-flow-units-per-vertex-buffer": 200,
 
   "tags": {
-    "locus": "idle-cluster_manager-node"
+    "locus": "idle-cluster_manager-node,data-node"
   },
 
   "remote-peers": ["ip1", "ip2", "ip3"],

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/RcaController.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/RcaController.java
@@ -177,7 +177,8 @@ public class RcaController {
                 return;
             }
 
-            subscriptionManager.setCurrentLocus(rcaConf.getTagMap().get("locus"));
+            String currentLocus = RcaUtil.getPriorityLocus(rcaConf.getTagMap().get("locus"));
+            subscriptionManager.setCurrentLocus(currentLocus);
             this.connectedComponents = getRcaGraphComponents(rcaConf);
 
             // Mute the rca nodes after the graph creation and before the scheduler start

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/Version.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/Version.java
@@ -19,11 +19,14 @@ public final class Version {
      * transferred packets should be dropped. Every increment here should be accompanied with a line
      * describing the version bump.
      *
-     * Note: The RCA version is agnostic of OpenSearch version.
+     * <p>Note: The RCA version is agnostic of OpenSearch version.
      */
     static final class Major {
-        // Bumping this post the Commons Lib(https://github.com/opensearch-project/performance-analyzer-commons/issues/2)
-        // and Service Metrics(https://github.com/opensearch-project/performance-analyzer-commons/issues/8) change
+        // Bumping this post the Commons
+        // Lib(https://github.com/opensearch-project/performance-analyzer-commons/issues/2)
+        // and Service
+        // Metrics(https://github.com/opensearch-project/performance-analyzer-commons/issues/8)
+        // change
         static final int RCA_MAJ_VERSION = 1;
     }
 

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/framework/util/RcaUtil.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/framework/util/RcaUtil.java
@@ -65,10 +65,6 @@ public class RcaUtil {
         }
         List<String> hostLociStrings =
                 Arrays.asList(hostLocus.split(RcaConsts.RcaTagConstants.SEPARATOR));
-        if (hostLociStrings.size() > 1
-                && hostLociStrings.contains(RcaConsts.RcaTagConstants.LOCUS_CLUSTER_MANAGER_NODE)) {
-            return RcaConsts.RcaTagConstants.LOCUS_CLUSTER_MANAGER_NODE;
-        }
         // Non-empty string was split -> guaranteed to be of size at least one.
         return hostLociStrings.get(0);
     }

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/store/OpenSearchAnalysisGraph.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/store/OpenSearchAnalysisGraph.java
@@ -183,7 +183,8 @@ public class OpenSearchAnalysisGraph extends AnalysisGraph {
         // Use EVALUATION_INTERVAL_SECONDS instead of RCA_PERIOD which resolved to 12 seconds.
         // This is resulting in this RCA not getting executed in every 5 seconds.
         Rca<ResourceFlowUnit<HotNodeSummary>> threadMetricsRca =
-                new ThreadMetricsRca(threadBlockedTime, threadWaitedTime, EVALUATION_INTERVAL_SECONDS);
+                new ThreadMetricsRca(
+                        threadBlockedTime, threadWaitedTime, EVALUATION_INTERVAL_SECONDS);
         threadMetricsRca.addTag(
                 RcaConsts.RcaTagConstants.TAG_LOCUS,
                 RcaConsts.RcaTagConstants.LOCUS_DATA_CLUSTER_MANAGER_NODE);
@@ -502,8 +503,7 @@ public class OpenSearchAnalysisGraph extends AnalysisGraph {
         Metric cpuUtilization = new CPU_Utilization(EVALUATION_INTERVAL_SECONDS);
 
         cpuUtilization.addTag(
-                RcaConsts.RcaTagConstants.TAG_LOCUS,
-                RcaConsts.RcaTagConstants.LOCUS_DATA_CLUSTER_MANAGER_NODE);
+                RcaConsts.RcaTagConstants.TAG_LOCUS, RcaConsts.RcaTagConstants.LOCUS_DATA_NODE);
 
         addLeaf(cpuUtilization);
 
@@ -511,8 +511,7 @@ public class OpenSearchAnalysisGraph extends AnalysisGraph {
         HotShardRca hotShardRca =
                 new HotShardRca(EVALUATION_INTERVAL_SECONDS, RCA_PERIOD, cpuUtilization);
         hotShardRca.addTag(
-                RcaConsts.RcaTagConstants.TAG_LOCUS,
-                RcaConsts.RcaTagConstants.LOCUS_DATA_CLUSTER_MANAGER_NODE);
+                RcaConsts.RcaTagConstants.TAG_LOCUS, RcaConsts.RcaTagConstants.LOCUS_DATA_NODE);
         hotShardRca.addAllUpstreams(Arrays.asList(cpuUtilization));
 
         // Hot Shard Cluster RCA which consumes the above

--- a/src/test/java/org/opensearch/performanceanalyzer/rca/store/ResourceHeatMapGraphTest.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/rca/store/ResourceHeatMapGraphTest.java
@@ -139,7 +139,8 @@ public class ResourceHeatMapGraphTest {
 
         RcaConf rcaConf = new RcaConf(dataNodeRcaConf);
         subscriptionManager = new SubscriptionManager(new GRPCConnectionManager(false));
-        subscriptionManager.setCurrentLocus(rcaConf.getTagMap().get("locus"));
+        String currentLocus = RcaUtil.getPriorityLocus(rcaConf.getTagMap().get("locus"));
+        subscriptionManager.setCurrentLocus(currentLocus);
 
         WireHopper wireHopper =
                 new WireHopper(
@@ -664,7 +665,8 @@ public class ResourceHeatMapGraphTest {
         RcaConf rcaConf = new RcaConf(dataNodeRcaConf);
         SubscriptionManager subscriptionManager =
                 new SubscriptionManager(new GRPCConnectionManager(false));
-        subscriptionManager.setCurrentLocus(rcaConf.getTagMap().get("locus"));
+        String currentLocus = RcaUtil.getPriorityLocus(rcaConf.getTagMap().get("locus"));
+        subscriptionManager.setCurrentLocus(currentLocus);
 
         AppContext appContext = RcaTestHelper.setMyIp("192.168.0.1", AllMetrics.NodeRole.DATA);
 
@@ -697,7 +699,8 @@ public class ResourceHeatMapGraphTest {
         RcaConf rcaConf2 = new RcaConf(clusterManagerNodeRcaConf);
         SubscriptionManager subscriptionManager2 =
                 new SubscriptionManager(new GRPCConnectionManager(false));
-        subscriptionManager2.setCurrentLocus(rcaConf2.getTagMap().get("locus"));
+        String currentLocus2 = RcaUtil.getPriorityLocus(rcaConf2.getTagMap().get("locus"));
+        subscriptionManager2.setCurrentLocus(currentLocus2);
 
         AppContext appContextClusterManager =
                 RcaTestHelper.setMyIp("192.168.0.4", AllMetrics.NodeRole.ELECTED_CLUSTER_MANAGER);


### PR DESCRIPTION
#308 
Changed the locus tag system to support multiple values in the config files. Now when having a non dedicated cluster manager node, including that info inside the `.conf` file will allow for execution of RCA nodes with only cluster manager OR data node tags. Also with a dedicated cluster manager node, only the cluster manager tagged RCA nodes will be executed.
Changed this for HotShardRCA for now, should switch for all other analyses at some point.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
