### PR TITLE
use mavenLocal as the first entry in repositories section

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -307,8 +307,8 @@ project.afterEvaluate {
 }
 
 repositories {
-    mavenCentral()
     mavenLocal()
+    mavenCentral()
     maven { url "https://aws.oss.sonatype.org/content/repositories/snapshots" }
 }
 


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
This PR resolves the first action item in https://github.com/opensearch-project/performance-analyzer-rca/issues/432, to use mavenLocal as the first entry in repositories section, to ensure that when core/min dependencies are published to maven local, gradle looks at maven local first and gets the required core/min dependencies rather than fetching from snapshots or maven central resulting in false checks.



### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
