### PR TITLE
fixing Mockito initialization issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -368,7 +368,11 @@ dependencies {
     // JDK9+ has to run powermock 2+. https://github.com/powermock/powermock/issues/888
     testImplementation group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.0'
     testImplementation group: 'org.powermock', name: 'powermock-module-junit4', version: '2.0.0'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '2.23.0'
+    implementation("org.mockito:mockito-core") {
+        version {
+            strictly "2.23.0"
+        }
+    }
     testImplementation group: 'org.powermock', name: 'powermock-core', version: '2.0.0'
     testImplementation group: 'org.powermock', name: 'powermock-api-support', version: '2.0.0'
     testImplementation group: 'org.powermock', name: 'powermock-module-junit4-common', version: '2.0.0'


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
Currently a lot of unit tests are failing with error:
```
java.lang.NoClassDefFoundError: Could not initialize class org.mockito.Mockito
```
We need to fix the `mockito-core` version to 2.23.0.

reference: https://github.com/mockito/mockito/issues/2568

**Describe the solution you are proposing**
A clear and concise description of what you want to happen.

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
