### PR TITLE
Update guava to address CVE-2023-2976

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
 
     dependencies {
         classpath "org.opensearch.gradle:build-tools:${opensearch_version}"
-        classpath group: 'com.google.guava', name: 'guava', version: '30.1-jre'
+        classpath group: 'com.google.guava', name: 'guava', version: '32.0.1-jre'
         classpath 'org.ajoberstar:gradle-git:0.2.3'
     }
 }
@@ -182,7 +182,7 @@ jacocoTestCoverageVerification {
                 }
             }
         }
-    } 
+    }
     else {
         violationRules {
             rule {
@@ -190,7 +190,7 @@ jacocoTestCoverageVerification {
                     minimum = 0.7
                 }
             }
-        }    
+        }
     }
 }
 
@@ -326,7 +326,7 @@ dependencies {
     compile 'org.bouncycastle:bcprov-jdk15on:1.70'
     compile 'org.bouncycastle:bcpkix-jdk15on:1.70'
     compile 'org.xerial:sqlite-jdbc:3.41.2.2'
-    compile 'com.google.guava:guava:30.1-jre'
+    compile 'com.google.guava:guava:32.0.1-jre'
     compile 'com.google.code.gson:gson:2.9.0'
     compile 'org.checkerframework:checker-qual:3.5.0'
     compile "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"


### PR DESCRIPTION
Update guava to address [CVE-2023-2976](https://www.cve.org/CVERecord?id=CVE-2023-2976).

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
