### PR TITLE
[CVE-2023-32732] Upgrade gRPC protobug to mitigate connection termincation issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -354,8 +354,8 @@ dependencies {
     implementation group: 'commons-io', name: 'commons-io', version: '2.7'
     implementation group: 'com.google.errorprone', name: 'error_prone_annotations', version: '2.9.0'
     implementation group: 'com.google.protobuf', name: 'protobuf-java', version: "${protobufVersion}"
-    implementation 'io.grpc:grpc-netty:1.52.1'
-    implementation 'io.grpc:grpc-protobuf:1.52.1'
+    implementation 'io.grpc:grpc-netty:1.56.1'
+    implementation 'io.grpc:grpc-protobuf:1.56.1'
     implementation("io.netty:netty-codec-http2:${nettyVersion}") {
         force = 'true'
     }


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
CVE-2023-32732 - gRPC connection termination issue on grpc-protobuf package versions lower than 1.52

**Describe the solution you are proposing**
Bumped up gRPC package version to 1.56

**Describe alternatives you've considered**
-

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
