### PR TITLE
[CVE-2023-32731] upgrade grpc version to 1.56.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -354,15 +354,15 @@ dependencies {
     implementation group: 'commons-io', name: 'commons-io', version: '2.7'
     implementation group: 'com.google.errorprone', name: 'error_prone_annotations', version: '2.9.0'
     implementation group: 'com.google.protobuf', name: 'protobuf-java', version: "${protobufVersion}"
-    implementation 'io.grpc:grpc-netty:1.52.1'
-    implementation 'io.grpc:grpc-protobuf:1.52.1'
+    implementation 'io.grpc:grpc-netty:1.56.1'
+    implementation 'io.grpc:grpc-protobuf:1.56.1'
     implementation("io.netty:netty-codec-http2:${nettyVersion}") {
         force = 'true'
     }
     implementation("io.netty:netty-handler-proxy:${nettyVersion}") {
         force = 'true'
     }
-    implementation 'io.grpc:grpc-stub:1.52.1'
+    implementation 'io.grpc:grpc-stub:1.56.1'
     implementation "jakarta.annotation:jakarta.annotation-api:${jakartaVersion}"
 
     // JDK9+ has to run powermock 2+. https://github.com/powermock/powermock/issues/888
@@ -405,7 +405,7 @@ protobuf {
 
     plugins {
         grpc {
-            artifact = 'io.grpc:protoc-gen-grpc-java:1.52.1'
+            artifact = 'io.grpc:protoc-gen-grpc-java:1.56.1'
         }
 
     }


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
CVE-2023-32731, CVE-2023-1428, CVE-2023-32732

**Describe the solution you are proposing**
Upgrading grpc version to 1.56.1 to address multiple cve issues.

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
