### PR TITLE
Handle string split on branch ref in gradle.yml

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -55,7 +55,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: opensearch-project/performance-analyzer
-        ref: 2.10
+        ref: '2.10'
         path: ./tmp/performance-analyzer
     - name: Build PA gradle using the new RCA jar
       working-directory: ./tmp/performance-analyzer


### PR DESCRIPTION
Handle string split on branch ref in gradle.yml. Without quotes, the string was getting split, leading to a branch reference as `2.1.0` instead of `2.10`

```
Execution failed for task ':updateShas'.
> Could not resolve all files for configuration ':runtimeClasspath'.
   > Could not find org.opensearch:performanceanalyzer-rca:2.1.0.0-SNAPSHOT.
     Searched in the following locations:
       - https://repo.maven.apache.org/maven2/org/opensearch/performanceanalyzer-rca/2.1.0.0-SNAPSHOT/maven-metadata.xml
       - https://repo.maven.apache.org/maven2/org/opensearch/performanceanalyzer-rca/2.1.0.0-SNAPSHOT/performanceanalyzer-rca-2.1.0.0-SNAPSHOT.pom
       - file:/home/runner/.m2/repository/org/opensearch/performanceanalyzer-rca/2.1.0.0-SNAPSHOT/maven-metadata.xml
> Task :updateShas FAILED
       - file:/home/runner/.m2/repository/org/opensearch/performanceanalyzer-rca/2.1.0.0-SNAPSHOT/performanceanalyzer-rca-2.1.0.0-SNAPSHOT.pom

```

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
