### PR TITLE
CVE fixes for v1.3.13 release 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -327,7 +327,7 @@ dependencies {
     compile 'org.bouncycastle:bcpkix-jdk15to18:1.74'
     compile 'org.xerial:sqlite-jdbc:3.41.2.2'
     compile 'com.google.guava:guava:32.0.1-jre'
-    compile 'com.google.code.gson:gson:2.9.0'
+    compile 'com.google.code.gson:gson:2.10.1'
     compile 'org.checkerframework:checker-qual:3.33.0'
     compile "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
     compile "com.fasterxml.jackson.core:jackson-databind:${jacksonDataBindVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -182,7 +182,7 @@ jacocoTestCoverageVerification {
                 }
             }
         }
-    } 
+    }
     else {
         violationRules {
             rule {
@@ -190,7 +190,7 @@ jacocoTestCoverageVerification {
                     minimum = 0.7
                 }
             }
-        }    
+        }
     }
 }
 
@@ -338,7 +338,7 @@ dependencies {
     compile group: 'com.google.errorprone', name: 'error_prone_annotations', version: '2.9.0'
     compile group: 'com.google.protobuf', name: 'protobuf-java', version: '3.21.8'
     implementation 'io.grpc:grpc-netty:1.49.0'
-    implementation 'io.grpc:grpc-protobuf:1.49.0'
+    implementation 'io.grpc:grpc-protobuf:1.53.0'
     implementation 'io.grpc:grpc-stub:1.49.0'
 
     implementation 'javax.annotation:javax.annotation-api:1.3.2'

--- a/build.gradle
+++ b/build.gradle
@@ -337,9 +337,9 @@ dependencies {
     compile group: 'commons-io', name: 'commons-io', version: '2.7'
     compile group: 'com.google.errorprone', name: 'error_prone_annotations', version: '2.9.0'
     compile group: 'com.google.protobuf', name: 'protobuf-java', version: '3.21.8'
-    implementation 'io.grpc:grpc-netty:1.49.0'
-    implementation 'io.grpc:grpc-protobuf:1.53.0'
-    implementation 'io.grpc:grpc-stub:1.49.0'
+    implementation 'io.grpc:grpc-netty:1.56.0'
+    implementation 'io.grpc:grpc-protobuf:1.56.0'
+    implementation 'io.grpc:grpc-stub:1.56.0'
 
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
     implementation("io.netty:netty-transport-native-unix-common:${nettyVersion}") {

--- a/src/main/java/org/opensearch/performanceanalyzer/decisionmaker/deciders/CacheHealthDecider.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/decisionmaker/deciders/CacheHealthDecider.java
@@ -78,8 +78,7 @@ public class CacheHealthDecider extends HeapBasedDecider {
 
         for (final ResourceEnum cacheType : modifyCacheActionPriorityList) {
             BaseClusterRca baseClusterRcaMap = cacheTypeBaseClusterRcaMap.get(cacheType);
-            if (baseClusterRcaMap == null)
-                continue;
+            if (baseClusterRcaMap == null) continue;
             getActionsFromRca(baseClusterRcaMap, impactedNodes).forEach(decision::addAction);
         }
         return decision;


### PR DESCRIPTION
CVE fixes for v1.3.13 release, upgrade the grpc protobuf and netty dependency to `1.56.0`

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
