### PR TITLE
Update Jooq version and address bind variable failure in AdmissionControl Emitter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -338,10 +338,16 @@ dependencies {
     def guavaVersion = "${versions.guava}"
     def jakartaVersion = "${versions.jakarta_annotation}"
 
-    implementation 'org.jooq:jooq:3.10.8'
+    // Sqlite and JOOQ version are coupled, see https://www.jooq.org/download/support-matrix
+    // In case they fall out of compatibility, JOOQ will throw error message:
+    // 'No bind variables have been provided with a single statement batch execution. This may be due to accidental API misuse>
+    def jooqVersion = "3.16.20"
+    def sqliteVersion = "3.41.2.2"
+
+    implementation "org.jooq:jooq:${jooqVersion}"
     implementation 'org.bouncycastle:bcprov-jdk15to18:1.74'
     implementation 'org.bouncycastle:bcpkix-jdk15to18:1.74'
-    implementation 'org.xerial:sqlite-jdbc:3.41.2.2'
+    implementation "org.xerial:sqlite-jdbc:${sqliteVersion}"
     implementation "com.google.guava:guava:${guavaVersion}"
     implementation 'com.google.code.gson:gson:2.9.0'
     implementation 'org.checkerframework:checker-qual:3.29.0'

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/persistence/SQLitePersistor.java
@@ -126,9 +126,7 @@ class SQLitePersistor extends PersistorBase {
     // It is needed during SQLite file rotation
     @Override
     synchronized void createNewDSLContext() {
-        if (create != null) {
-            create.close();
-        }
+        // No need to close DSL Context in Jooq 3.16+, see https://github.com/jOOQ/jOOQ/issues/10512
         create = DSL.using(super.conn, SQLDialect.SQLITE);
         jooqTableColumns = new HashMap<>();
         tableNameToJavaClassMap = new HashMap<>();
@@ -413,7 +411,7 @@ class SQLitePersistor extends PersistorBase {
 
                     // This gives the type of the setter parameter.
                     Class<?> setterType = setter.getParameterTypes()[0];
-                    int nestedRowId = jooqField.cast(Integer.class).getValue(record);
+                    int nestedRowId = record.getValue(jooqField, Integer.class);
 
                     // Now that we have the Type of the parameter and the rowID specifying the data
                     // the object

--- a/src/main/java/org/opensearch/performanceanalyzer/reader/MetricsEmitter.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/reader/MetricsEmitter.java
@@ -914,7 +914,6 @@ public class MetricsEmitter {
             if (controllerObj.isPresent() && rejectionCountObj.isPresent()) {
                 handle.bind(
                         controllerObj.orElseGet(Object::new).toString(),
-                        rejectionCountObj.map(o -> Long.parseLong(o.toString())).orElse(0L),
                         // the rest are agg fields: sum, avg, min, max
                         rejectionCountObj.map(o -> Long.parseLong(o.toString())).orElse(0L),
                         rejectionCountObj.map(o -> Long.parseLong(o.toString())).orElse(0L),

--- a/src/test/java/org/opensearch/performanceanalyzer/reader/MetricsEmitterTests.java
+++ b/src/test/java/org/opensearch/performanceanalyzer/reader/MetricsEmitterTests.java
@@ -25,7 +25,9 @@ import org.jooq.Result;
 import org.jooq.SQLDialect;
 import org.jooq.impl.DSL;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+import org.opensearch.performanceanalyzer.PerformanceAnalyzerApp;
 import org.opensearch.performanceanalyzer.commons.metrics.AllMetrics;
 import org.opensearch.performanceanalyzer.commons.metrics.PerformanceAnalyzerMetrics;
 import org.opensearch.performanceanalyzer.config.TroubleshootingConfig;
@@ -43,6 +45,11 @@ public class MetricsEmitterTests extends AbstractReaderTests {
     }
 
     private static final String DB_URL = "jdbc:sqlite:";
+
+    @Before
+    public void setup() {
+        PerformanceAnalyzerApp.initAggregators();
+    }
 
     @Test
     public void testMetricsEmitter() throws Exception {


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
https://github.com/opensearch-project/performance-analyzer-rca/issues/492

**Describe the solution you are proposing**
1. Update Jooq version to `3.16.20`, compatible with sqlite version 
2. Fix error in AdmissionControl Emitter (`AdmissionControl_RejectionCount` configured with 5 columns but the AD Emitter code attempts to bind 6 values, causing failure)
3. Jooq version upgrade related changes 

Tested within RCA Docker container, No more `org.jooq.tools.JooqLogger info INFO: Single batch             : No bind variables have been provided with a single statement batch execution. This may be due to accidental API misuse` present in `[root@d47462e53343 logs]# cat PerformanceAnalyzer.log  | grep bind`
```
[root@d47462e53343 logs]# pwd
/usr/share/opensearch/logs
[root@d47462e53343 logs]# cat PerformanceAnalyzer.log  | grep bind
```

### Check List
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
