### PR TITLE
[Backport 2.x] Add new maintainers to repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @praveensameneni @khushbr @ansjcy @goyamegh @getsaurabh02 @sbcd90 @sgup432 @arjunkumargiri
+*   @khushbr @ansjcy @sbcd90 @devagarwal1803 @Shephalimittal @atharvasharma61 @nishchay21 @DevJhaAbhishek @varunsrivathsav @rramachand21

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,23 +4,31 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Current Maintainers
 
-| Maintainer       | GitHub ID                                             | Affiliation |
-|------------------|-------------------------------------------------------| ----------- |
-| Praveen Sameneni | [praveensameneni](https://github.com/praveensameneni) | Amazon      |
-| Khushboo Rajput  | [khushbr](https://github.com/khushbr)                 | Amazon      |
-| Chenyang Ji      | [ansjcy](https://github.com/ansjcy)                   | Amazon      |
-| Megha Goyal      | [goyamegh](https://github.com/goyamegh)               | Amazon      |
-| Saurabh Singh    | [getsaurabh02](https://github.com/getsaurabh02)       | Amazon      |
-| Subhobrata Dey   | [sbcd90](https://github.com/sbcd90)                   | Amazon      |
-| Sagar            | [sgup432](https://github.com/sgup432)                 | Amazon      |
-| Arjun Kumar Giri | [arjunkumargiri](https://github.com/arjunkumargiri)   | Amazon      |
+| Maintainer                | GitHub ID                                             | Affiliation |
+|---------------------------|-------------------------------------------------------| ----------- |
+| Khushboo Rajput           | [khushbr](https://github.com/khushbr)                 | Amazon      |
+| Chenyang Ji               | [ansjcy](https://github.com/ansjcy)                   | Amazon      |
+| Subhobrata Dey            | [sbcd90](https://github.com/sbcd90)                   | Amazon      |
+| Dev Agarwal               | [devagarwal1803](https://github.com/devagarwal1803)   | Amazon      |
+| shephali mittal           | [Shephalimittal](https://github.com/Shephalimittal)   | Amazon      |
+| Atharva Sharma            | [atharvasharma61](https://github.com/atharvasharma61) | Amazon      |
+| Nishchay Malhotra         | [nishchay21](https://github.com/nishchay21)           | Amazon      |
+| DevJhaAbhishek            | [DevJhaAbhishek](https://github.com/DevJhaAbhishek)   | Amazon      |
+| Varunsrivathsa Venkatesha | [varunsrivathsav](https://github.com/varunsrivathsav) | Amazon      |
+| Ranjith Ramachandra       | [rramachand21](https://github.com/rramachand21)       | Amazon      |
+
 
 ## Previous Maintainers
 
-| Maintainer      | GitHub ID                                   | Affiliation |
-|-----------------|---------------------------------------------|-------------|
-| Joshua Tokle    | [jotok](https://github.com/jotok)           | Amazon      |
-| Ruizhen Guo     | [rguo-aws](https://github.com/rguo-aws)     | Amazon      |
-| Yujia Sun       | [yujias0706](https://github.com/yujias0706) | Amazon      |
-| Kunal Khatua    | [kkhatua](https://github.com/kkhatua)       | Amazon      |
-| Sruti Parthiban | [sruti1312](https://github.com/sruti1312)   | Amazon      |
+| Maintainer        | GitHub ID                                             | Affiliation |
+|-------------------|-------------------------------------------------------|-------------|
+| Joshua Tokle      | [jotok](https://github.com/jotok)                     | Amazon      |
+| Ruizhen Guo       | [rguo-aws](https://github.com/rguo-aws)               | Amazon      |
+| Yujia Sun         | [yujias0706](https://github.com/yujias0706)           | Amazon      |
+| Kunal Khatua      | [kkhatua](https://github.com/kkhatua)                 | Amazon      |
+| Sruti Parthiban   | [sruti1312](https://github.com/sruti1312)             | Amazon      |
+| Praveen Sameneni  | [praveensameneni](https://github.com/praveensameneni) | Amazon      |
+| Saurabh Singh     | [getsaurabh02](https://github.com/getsaurabh02)       | Amazon      |
+| Megha Goyal       | [goyamegh](https://github.com/goyamegh)               | Amazon      |
+| Sagar             | [sgup432](https://github.com/sgup432)                 | Amazon      |
+| Arjun Kumar Giri | [arjunkumargiri](https://github.com/arjunkumargiri)   | Amazon      |

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,10 @@ buildscript {
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         buildDockerJdkVersion = System.getProperty("build.docker_jdk_ver", "11")
 
+        // The PA Commons (https://github.com/opensearch-project/performance-analyzer-commons)
+        // is a library dependency with hardcoded versioning in PA and RCA repos.
+        paCommonsVersion = "1.3.0"
+
         // 2.x.0-SNAPSHOT -> 2.x.0.0-SNAPSHOT
         version_tokens = opensearch_version.tokenize('-')
         opensearch_build = version_tokens[0] + '.0'
@@ -19,8 +23,9 @@ buildscript {
         }
         if (isSnapshot) {
             opensearch_build += "-SNAPSHOT"
+            paCommonsVersion += "-SNAPSHOT"
         }
-        gitPaBranch = '2.10'
+        gitPaBranch = '2.12'
         gitPaRepo = "https://github.com/opensearch-project/performance-analyzer.git"
         runGauntletTests = "true" == System.getProperty("run.gauntlet.tests", "false")
     }
@@ -353,7 +358,7 @@ dependencies {
     implementation 'org.checkerframework:checker-qual:3.29.0'
     implementation "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
     implementation "com.fasterxml.jackson.core:jackson-databind:${jacksonDataBindVersion}"
-    implementation "org.opensearch:performance-analyzer-commons:1.1.0-SNAPSHOT"
+    implementation "org.opensearch:performance-analyzer-commons:${paCommonsVersion}"
     implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: "${log4jVersion}"
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: "${log4jVersion}"
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: "${commonslangVersion}"


### PR DESCRIPTION
Back-porting https://github.com/opensearch-project/performance-analyzer-rca/pull/522 to 2.x


### Check List
- [x] Backport Labels added.   
- [ ] New functionality includes testing.
  - [x] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
