### PR TITLE
[1.3] Bump netty to match version from core's buildSrc/version.properties and bump grpc to 1.56.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -337,9 +337,11 @@ dependencies {
     compile group: 'commons-io', name: 'commons-io', version: '2.7'
     compile group: 'com.google.errorprone', name: 'error_prone_annotations', version: '2.9.0'
     compile group: 'com.google.protobuf', name: 'protobuf-java', version: '3.21.8'
-    implementation 'io.grpc:grpc-netty:1.56.0'
-    implementation 'io.grpc:grpc-protobuf:1.56.0'
-    implementation 'io.grpc:grpc-stub:1.56.0'
+    implementation 'io.grpc:grpc-netty:1.56.1'
+    implementation 'io.grpc:grpc-protobuf:1.56.1'
+    implementation("io.netty:netty-codec-http2:${nettyVersion}")
+    implementation("io.netty:netty-handler-proxy:${nettyVersion}")
+    implementation 'io.grpc:grpc-stub:1.52.1'
 
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
     implementation("io.netty:netty-transport-native-unix-common:${nettyVersion}") {


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**

This PR will match the `build.gradle` file on main here: https://github.com/opensearch-project/performance-analyzer-rca/blob/main/build.gradle#L373-L377

The dependencies on main should be updated or dependabot added to this repo if its not enabled already.

Without this change performance-analyzer-rca is being bundled with netty-codec-http-4.1.87.Final.jar, netty-codec-http2-4.1.87.Final.jar and netty-handler-4.1.87.Final.jar which are affected by https://avd.aquasec.com/nvd/cve-2024-29025, https://github.com/advisories/GHSA-xpw8-rcwv-8f8p and https://avd.aquasec.com/nvd/cve-2023-34462 respectively.

### Check List
- [ ] Backport Labels added.   
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
