### PR TITLE
Bump bouncycastle from 1.74 to 1.78.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -355,8 +355,8 @@ dependencies {
     def sqliteVersion = "3.41.2.2"
 
     implementation "org.jooq:jooq:${jooqVersion}"
-    implementation 'org.bouncycastle:bcprov-jdk15to18:1.74'
-    implementation 'org.bouncycastle:bcpkix-jdk15to18:1.74'
+    implementation 'org.bouncycastle:bcprov-jdk15to18:1.78.1'
+    implementation 'org.bouncycastle:bcpkix-jdk15to18:1.78.1'
     implementation "org.xerial:sqlite-jdbc:${sqliteVersion}"
     implementation "com.google.guava:guava:${guavaVersion}"
     implementation 'com.google.code.gson:gson:2.9.0'


### PR DESCRIPTION
BouncyCastle upgrades from 1.74 to 1.78.1.

Related Issues

Resolves https://github.com/advisories/GHSA-m44j-cfrm-g8qc, https://github.com/advisories/GHSA-v435-xc8x-wvr9 and https://github.com/advisories/GHSA-8xfc-gm6g-vgpv.

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [ ] Backport Labels added.   
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
