### PR TITLE
Added telemetry-collectors-enabled flag in performance-analyzer.properties

### DIFF
--- a/config/performance-analyzer.properties
+++ b/config/performance-analyzer.properties
@@ -44,3 +44,5 @@ plugin-stats-metadata = plugin-stats-metadata
 # Agent Stats Metadata file name, expected to be in the same location
 agent-stats-metadata = agent-stats-metadata
 
+# Flag to enable/disable telemetry collectors
+telemetry-collectors-enabled = false


### PR DESCRIPTION
Added telemetry-collectors-enabled flag in performance-analyzer.properties. 

**Describe the solution you are proposing**
Added telemetry-collectors-enabled flag in performance-analyzer.properties to control telemetry related collectors. 

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [ ] Backport Labels added.   
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
