### PR TITLE
[Release 2.16.0] CVE fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -355,8 +355,8 @@ dependencies {
     def sqliteVersion = "3.41.2.2"
 
     implementation "org.jooq:jooq:${jooqVersion}"
-    implementation 'org.bouncycastle:bcprov-jdk15to18:1.74'
-    implementation 'org.bouncycastle:bcpkix-jdk15to18:1.74'
+    implementation 'org.bouncycastle:bcprov-jdk15to18:1.78.1'
+    implementation 'org.bouncycastle:bcpkix-jdk15to18:1.78.1'
     implementation "org.xerial:sqlite-jdbc:${sqliteVersion}"
     implementation "com.google.guava:guava:${guavaVersion}"
     implementation 'com.google.code.gson:gson:2.9.0'


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
Coming from https://build.ci.opensearch.org/job/docker-scan/3648/artifact/scan_docker_image.txt, fix the CVE's for 2.16.0 release. Using the version of `bcprov-jdk15to18` and `bcpkix-jdk15to18` from [main branch](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/build.gradle#L359C38-L359C54).


**Additional context**
Part of https://github.com/opensearch-project/opensearch-build/issues/4771

### Check List
- [ ] Backport Labels added.   
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
