### PR TITLE
[BugFix] Added try catch block for createContext in http

### DIFF
--- a/src/main/java/org/opensearch/performanceanalyzer/core/Util.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/core/Util.java
@@ -17,7 +17,7 @@ public class Util {
     private static final Logger LOG = LogManager.getLogger(Util.class);
 
     public static final String PA_BASE_URL = "/_plugins/_performanceanalyzer";
-    public static final String LEGACY_OPENDISTRO_PA_BASE_URL = PA_BASE_URL;
+    public static final String LEGACY_OPENDISTRO_PA_BASE_URL = "/_opendistro/_performanceanalyzer";
 
     public static final String METRICS_QUERY_URL = PA_BASE_URL + "/metrics";
     public static final String LEGACY_OPENDISTRO_METRICS_QUERY_URL =

--- a/src/main/java/org/opensearch/performanceanalyzer/rca/RcaController.java
+++ b/src/main/java/org/opensearch/performanceanalyzer/rca/RcaController.java
@@ -527,14 +527,36 @@ public class RcaController {
     }
 
     private void addRcaRequestHandler() {
-        httpServer.createContext(Util.RCA_QUERY_URL, queryRcaRequestHandler);
-        httpServer.createContext(Util.LEGACY_OPENDISTRO_RCA_QUERY_URL, queryRcaRequestHandler);
+        try {
+            httpServer.createContext(Util.RCA_QUERY_URL, queryRcaRequestHandler);
+        } catch (IllegalArgumentException e) {
+            LOG.error("unable to create context in http server for URL: " + Util.RCA_QUERY_URL);
+        }
+
+        try {
+            httpServer.createContext(Util.LEGACY_OPENDISTRO_RCA_QUERY_URL, queryRcaRequestHandler);
+        } catch (IllegalArgumentException e) {
+            LOG.error(
+                    "unable to create context in http server for URL: "
+                            + Util.LEGACY_OPENDISTRO_RCA_QUERY_URL);
+        }
     }
 
     private void addActionsRequestHandler() {
-        httpServer.createContext(Util.ACTIONS_QUERY_URL, queryActionRequestHandler);
-        httpServer.createContext(
-                Util.LEGACY_OPENDISTRO_ACTIONS_QUERY_URL, queryActionRequestHandler);
+        try {
+            httpServer.createContext(Util.ACTIONS_QUERY_URL, queryActionRequestHandler);
+        } catch (IllegalArgumentException e) {
+            LOG.error("unable to create context in http server for URL: " + Util.ACTIONS_QUERY_URL);
+        }
+
+        try {
+            httpServer.createContext(
+                    Util.LEGACY_OPENDISTRO_ACTIONS_QUERY_URL, queryActionRequestHandler);
+        } catch (IllegalArgumentException e) {
+            LOG.error(
+                    "unable to create context in http server for URL: "
+                            + Util.LEGACY_OPENDISTRO_ACTIONS_QUERY_URL);
+        }
     }
 
     public void setDeliberateInterrupt() {


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
resolves #545 

**Describe the solution you are proposing**
httpServer.createContext throws illegalArgumentException when called more than once for same parameters. This commit ensures to avoid such scenarios in the PerformanceAnalyzerApp main class by fixing the legacy parameter. This commit also ensures that the RcaController thread gracefully handles the similar situation when RcaController thread is killed and respawned.

**Describe alternatives you've considered**


**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [x] Backport Labels added.   
- [x] New functionality includes testing.
  - [x] All tests pass
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
