### PR TITLE
Upgrade actions/upload-artifact from v2 to v3

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -33,7 +33,7 @@ jobs:
       working-directory:  ./tmp/performance-analyzer-rca
       run: ./gradlew build --stacktrace
     - name: Upload reports
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: gradle-reports
         path: ./tmp/performance-analyzer-rca/build/reports


### PR DESCRIPTION
**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**

This PR does an upgrade of the actions/upload-artifact github action from v2 to v3 to resolve errors seen in CI checks like https://github.com/opensearch-project/performance-analyzer-rca/actions/runs/11485849764/job/31966863799?pr=577

### Check List
- [ ] Backport Labels added.   
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
