### PR TITLE
Fixes CVE-2024-47554

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -367,7 +367,7 @@ dependencies {
     implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: "${log4jVersion}"
     implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: "${log4jVersion}"
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: "${commonslangVersion}"
-    implementation group: 'commons-io', name: 'commons-io', version: '2.14.0'
+    implementation group: 'commons-io', name: 'commons-io', version: '2.16.0'
     implementation group: 'com.google.errorprone', name: 'error_prone_annotations', version: '2.9.0'
     implementation group: 'com.google.protobuf', name: 'protobuf-java', version: "${protobufVersion}"
     implementation 'io.grpc:grpc-netty:1.68.1'


### PR DESCRIPTION
Upgrading the commons-io version to 2.16.0 to fix CVE-2024-47554.

**Is your feature request related to a problem? Please provide an existing Issue # , or describe.**
A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

**Describe the solution you are proposing**
A clear and concise description of what you want to happen.

**Describe alternatives you've considered**
A clear and concise description of any alternative solutions or features you've considered.

**Additional context**
Add any other context or screenshots about the feature request here.

### Check List
- [ ] Backport Labels added.   
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/performance-analyzer-rca/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
