### PR TITLE
Propose moving inactivie Maintainers to Emeritus

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @khushbr @ansjcy @sbcd90 @devagarwal1803 @Shephalimittal @atharvasharma61 @nishchay21 @DevJhaAbhishek @varunsrivathsav @rramachand21
+*   @ansjcy @sbcd90 @devagarwal1803 @Shephalimittal @atharvasharma61 @nishchay21 @DevJhaAbhishek @varunsrivathsav @rramachand21

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @ansjcy @sbcd90 @devagarwal1803 @Shephalimittal @atharvasharma61 @nishchay21 @DevJhaAbhishek @varunsrivathsav @rramachand21
+*   @ansjcy @sbcd90 @Shephalimittal @nishchay21 @rramachand21

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,12 +8,8 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 |---------------------------|-------------------------------------------------------| ----------- |
 | Chenyang Ji               | [ansjcy](https://github.com/ansjcy)                   | Amazon      |
 | Subhobrata Dey            | [sbcd90](https://github.com/sbcd90)                   | Amazon      |
-| Dev Agarwal               | [devagarwal1803](https://github.com/devagarwal1803)   | Amazon      |
 | shephali mittal           | [Shephalimittal](https://github.com/Shephalimittal)   | Amazon      |
-| Atharva Sharma            | [atharvasharma61](https://github.com/atharvasharma61) | Amazon      |
 | Nishchay Malhotra         | [nishchay21](https://github.com/nishchay21)           | Amazon      |
-| DevJhaAbhishek            | [DevJhaAbhishek](https://github.com/DevJhaAbhishek)   | Amazon      |
-| Varunsrivathsa Venkatesha | [varunsrivathsav](https://github.com/varunsrivathsav) | Amazon      |
 | Ranjith Ramachandra       | [rramachand21](https://github.com/rramachand21)       | Amazon      |
 
 
@@ -32,3 +28,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Sagar             | [sgup432](https://github.com/sgup432)                 | Amazon      |
 | Arjun Kumar Giri  | [arjunkumargiri](https://github.com/arjunkumargiri)   | Amazon      |
 | Khushboo Rajput   | [khushbr](https://github.com/khushbr)                 | Amazon      |
+| Dev Agarwal       | [devagarwal1803](https://github.com/devagarwal1803)   | Amazon      |
+| Atharva Sharma    | [atharvasharma61](https://github.com/atharvasharma61) | Amazon      |
+| DevJhaAbhishek    | [DevJhaAbhishek](https://github.com/DevJhaAbhishek)   | Amazon      |
+| Varunsrivathsa Venkatesha | [varunsrivathsav](https://github.com/varunsrivathsav) | Amazon      |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,7 +6,6 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 | Maintainer                | GitHub ID                                             | Affiliation |
 |---------------------------|-------------------------------------------------------| ----------- |
-| Khushboo Rajput           | [khushbr](https://github.com/khushbr)                 | Amazon      |
 | Chenyang Ji               | [ansjcy](https://github.com/ansjcy)                   | Amazon      |
 | Subhobrata Dey            | [sbcd90](https://github.com/sbcd90)                   | Amazon      |
 | Dev Agarwal               | [devagarwal1803](https://github.com/devagarwal1803)   | Amazon      |
@@ -31,4 +30,5 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Saurabh Singh     | [getsaurabh02](https://github.com/getsaurabh02)       | Amazon      |
 | Megha Goyal       | [goyamegh](https://github.com/goyamegh)               | Amazon      |
 | Sagar             | [sgup432](https://github.com/sgup432)                 | Amazon      |
-| Arjun Kumar Giri | [arjunkumargiri](https://github.com/arjunkumargiri)   | Amazon      |
+| Arjun Kumar Giri  | [arjunkumargiri](https://github.com/arjunkumargiri)   | Amazon      |
+| Khushboo Rajput   | [khushbr](https://github.com/khushbr)                 | Amazon      |


### PR DESCRIPTION
Hey @khushbr, @devagarwal1803, @atharvasharma61, @DevJhaAbhishek, @varunsrivathsav , we see you haven't used your maintainer privileges in the [past year](https://metrics.opensearch.org/_dashboards/app/dashboards?security_tenant=global#/view/30fedc30-9ae2-11ef-a168-f19b1bbc360c?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-30d,to:now))&_a=(description:'Shows%20data%20about%20the%20activity%20of%20maintainers%20in%20the%20OpenSearch%20Project(since%2010-12-24,%20and%20the%20technical-steering%20repo%20since%2011-7-24).%20',filters:!(),fullScreenMode:!f,options:(hidePanelTitles:!f,useMargins:!t),query:(language:kuery,query:''),timeRestore:!t,title:'OpenSearch%20Maintainer%20Dashboard',viewMode:view)) for this repo. 

If you plan on continuing to contribute, please respond here and close this PR. Otherwise, per our [inactivity policy](https://github.com/opensearch-project/technical-steering/blob/main/policies/RESPONSIBILITIES.md#inactivity) you'll be moved to emeritus, but you can move back to active status at any time.